### PR TITLE
Fix lint warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -98,6 +103,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "apic"
+version = "0.1.0"
+dependencies = [
+ "atomic_linked_list",
+ "bit_field",
+ "crossbeam-utils",
+ "irq_safety",
+ "kernel_config",
+ "lazy_static",
+ "log",
+ "memory",
+ "owning_ref",
+ "pit_clock",
+ "raw-cpuid",
+ "spin 0.9.2",
+ "static_assertions",
+ "volatile",
+ "x86_64",
+ "zerocopy",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +143,10 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic_linked_list"
+version = "0.1.0"
 
 [[package]]
 name = "atty"
@@ -151,8 +182,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.26.0",
+ "object 0.26.2",
  "rustc-demangle",
+]
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -211,6 +251,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bit_field"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff91a64014e1bc53bf643920f2c9ab5f0980d92a0948295f3ee550e9266849ad"
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +275,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bootloader_modules"
+version = "0.1.0"
+dependencies = [
+ "memory_structs",
 ]
 
 [[package]]
@@ -264,7 +323,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "rustc_version",
+ "rustc_version 0.4.0",
  "winapi",
 ]
 
@@ -282,7 +341,7 @@ dependencies = [
  "maybe-owned",
  "once_cell",
  "rsix",
- "rustc_version",
+ "rustc_version 0.4.0",
  "unsafe-io",
  "winapi",
  "winapi-util",
@@ -309,7 +368,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "rsix",
- "rustc_version",
+ "rustc_version 0.4.0",
  "unsafe-io",
 ]
 
@@ -362,7 +421,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -498,6 +557,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
 
 [[package]]
+name = "context_switch"
+version = "0.1.0"
+dependencies = [
+ "cfg-if 0.1.10",
+ "context_switch_avx",
+ "context_switch_regular",
+ "context_switch_sse",
+]
+
+[[package]]
+name = "context_switch_avx"
+version = "0.1.0"
+dependencies = [
+ "context_switch_regular",
+ "zerocopy",
+]
+
+[[package]]
+name = "context_switch_regular"
+version = "0.1.0"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "context_switch_sse"
+version = "0.1.0"
+dependencies = [
+ "context_switch_regular",
+ "zerocopy",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "cow_arc"
+version = "0.1.0"
+dependencies = [
+ "owning_ref",
+ "spin 0.9.2",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,7 +687,7 @@ dependencies = [
  "cranelift-entity",
  "criterion",
  "gimli",
- "hashbrown",
+ "hashbrown 0.11.2",
  "log",
  "peepmatic",
  "peepmatic-runtime",
@@ -612,7 +748,7 @@ name = "cranelift-frontend"
 version = "0.77.0"
 dependencies = [
  "cranelift-codegen",
- "hashbrown",
+ "hashbrown 0.11.2",
  "log",
  "smallvec",
  "target-lexicon",
@@ -655,7 +791,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "region",
+ "region 2.2.0",
  "target-lexicon",
  "winapi",
 ]
@@ -667,7 +803,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-entity",
- "hashbrown",
+ "hashbrown 0.11.2",
  "log",
 ]
 
@@ -690,7 +826,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-module",
  "log",
- "object 0.26.0",
+ "object 0.26.2",
  "target-lexicon",
 ]
 
@@ -767,22 +903,45 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "hashbrown",
+ "hashbrown 0.11.2",
  "itertools 0.10.0",
  "log",
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
  "wasmtime-types",
  "wat",
 ]
 
 [[package]]
+name = "crate_metadata"
+version = "0.1.0"
+dependencies = [
+ "cow_arc",
+ "fs_node",
+ "goblin",
+ "hashbrown 0.11.2",
+ "log",
+ "memory",
+ "spin 0.9.2",
+ "xmas-elf",
+]
+
+[[package]]
+name = "crate_name_utils"
+version = "0.1.0"
+dependencies = [
+ "crate_metadata",
+ "itertools 0.7.11",
+ "path",
+]
+
+[[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -853,7 +1012,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -887,6 +1046,16 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "cstr_core"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+dependencies = [
+ "cty",
+ "memchr",
 ]
 
 [[package]]
@@ -968,6 +1137,19 @@ checksum = "5f1281ee141df08871db9fe261ab5312179eac32d1e314134ceaa8dd7c042f5a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
  "syn",
 ]
 
@@ -1075,10 +1257,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-hal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "entryflags_x86_64"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "multiboot2",
+ "static_assertions",
+ "xmas-elf",
+]
 
 [[package]]
 name = "env_logger"
@@ -1104,6 +1306,14 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "environment"
+version = "0.1.0"
+dependencies = [
+ "fs_node",
+ "root",
 ]
 
 [[package]]
@@ -1194,6 +1404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "frame_allocator"
+version = "0.1.0"
+dependencies = [
+ "intrusive-collections",
+ "kernel_config",
+ "log",
+ "memory_structs",
+ "page_table_entry",
+ "spin 0.9.2",
+ "static_assertions",
+]
+
+[[package]]
 name = "fs-set-times"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1425,17 @@ dependencies = [
  "io-lifetimes",
  "rsix",
  "winapi",
+]
+
+[[package]]
+name = "fs_node"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "memory",
+ "spin 0.9.2",
+ "x86_64",
 ]
 
 [[package]]
@@ -1276,7 +1510,7 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 dependencies = [
  "fallible-iterator",
  "indexmap",
- "stable_deref_trait",
+ "stable_deref_trait 1.2.0",
 ]
 
 [[package]]
@@ -1284,6 +1518,16 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "goblin"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65cd533b33e3d04c6e393225fa8919ddfcf5862ca8919c7f9a167c312ef41c2"
+dependencies = [
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "group"
@@ -1307,6 +1551,12 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
@@ -1377,7 +1627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
@@ -1403,12 +1653,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb484b70a4ebad7f571bf84e9cd06b5bfb6a7e4db0c36e13dd1570c6b449c10d"
+dependencies = [
+ "memoffset 0.5.6",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f5ce4afb9bf504b9f496a3307676bc232122f91a93c4da6d540aa99a0a0e0b"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
  "winapi",
 ]
 
@@ -1417,6 +1676,26 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
+name = "irq_safety"
+version = "0.1.1"
+source = "git+https://github.com/theseus-os/irq_safety#4ab38e655d68baa6a317ed4d6c589ecc30f4c843"
+dependencies = [
+ "cortex-m",
+ "owning_ref",
+ "spin 0.9.2",
+ "stable_deref_trait 1.1.1",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1482,12 +1761,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel_config"
+version = "0.1.0"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -1590,12 +1873,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memfs"
+version = "0.1.0"
+dependencies = [
+ "fs_node",
+ "irq_safety",
+ "log",
+ "memory",
+ "spin 0.9.2",
+ "x86_64",
+]
+
+[[package]]
 name = "memmap2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1608,10 +1912,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory"
+version = "0.1.0"
+dependencies = [
+ "atomic_linked_list",
+ "bit_field",
+ "bitflags",
+ "frame_allocator",
+ "irq_safety",
+ "kernel_config",
+ "lazy_static",
+ "log",
+ "memory_structs",
+ "memory_x86_64",
+ "multiboot2",
+ "page_allocator",
+ "page_table_entry",
+ "spin 0.9.2",
+ "x86_64",
+ "xmas-elf",
+ "zerocopy",
+]
+
+[[package]]
+name = "memory_structs"
+version = "0.1.0"
+dependencies = [
+ "bit_field",
+ "derive_more",
+ "entryflags_x86_64",
+ "kernel_config",
+ "multiboot2",
+ "paste",
+ "xmas-elf",
+ "zerocopy",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+
+[[package]]
+name = "memory_x86_64"
+version = "0.1.0"
+dependencies = [
+ "entryflags_x86_64",
+ "kernel_config",
+ "log",
+ "memory_structs",
+ "multiboot2",
+ "x86_64",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1646,10 +1999,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "mod_mgmt"
+version = "0.1.0"
+dependencies = [
+ "bootloader_modules",
+ "cow_arc",
+ "crate_metadata",
+ "crate_name_utils",
+ "cstr_core",
+ "fs_node",
+ "hashbrown 0.11.2",
+ "kernel_config",
+ "lazy_static",
+ "log",
+ "memfs",
+ "memory",
+ "path",
+ "qp-trie",
+ "rangemap",
+ "root",
+ "rustc-demangle",
+ "spin 0.9.2",
+ "util",
+ "vfs_node",
+ "xmas-elf",
+]
+
+[[package]]
 name = "more-asserts"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "multiboot2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e9fc890ff2ef2ded9084c964b950da1bc9e26d480e446ae721607b899db1fd"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "mutex_sleep"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "owning_ref",
+ "spin 0.9.2",
+ "stable_deref_trait 1.1.1",
+ "task",
+ "wait_queue",
+]
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
@@ -1661,7 +2083,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.4",
 ]
 
 [[package]]
@@ -1774,9 +2196,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "crc32fast",
  "indexmap",
@@ -1785,10 +2207,10 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 dependencies = [
  "crc32fast",
- "hashbrown",
+ "hashbrown 0.11.2",
  "indexmap",
  "memchr",
 ]
@@ -1879,6 +2301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "git+https://github.com/theseus-os/owning-ref-rs.git#0d2dcdcffd75b80157d0e72fb82593a8696a9c49"
+dependencies = [
+ "spin 0.9.2",
+ "stable_deref_trait 1.1.1",
+]
+
+[[package]]
 name = "p256"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +2318,28 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+]
+
+[[package]]
+name = "page_allocator"
+version = "0.1.0"
+dependencies = [
+ "intrusive-collections",
+ "kernel_config",
+ "log",
+ "memory_structs",
+ "spin 0.9.2",
+ "static_assertions",
+]
+
+[[package]]
+name = "page_table_entry"
+version = "0.1.0"
+dependencies = [
+ "bit_field",
+ "kernel_config",
+ "memory_structs",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1925,6 +2378,27 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "path"
+version = "0.1.0"
+dependencies = [
+ "fs_node",
+ "lazy_static",
+ "log",
+ "root",
+ "spin 0.9.2",
+ "vfs_node",
+ "x86_64",
+]
+
+[[package]]
+name = "path_std"
+version = "0.1.0"
+dependencies = [
+ "core2 0.3.3",
+ "task",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -2052,6 +2526,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
+name = "pit_clock"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "port_io",
+ "spin 0.9.2",
+ "x86_64",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2558,12 @@ dependencies = [
  "spki",
  "zeroize",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2125,6 +2615,10 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "port_io"
+version = "0.2.1"
 
 [[package]]
 name = "ppv-lite86"
@@ -2245,6 +2739,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "qp-trie"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c28ae173e3e75d238fc7f558664fd6700d49a3a5a465d61671227e042dc747"
+dependencies = [
+ "new_debug_unreachable",
+ "unreachable",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2860,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3929836cb64d09ee7deee59635c3d9bffbc1c0373e247efff6272abd62a11baa"
+
+[[package]]
+name = "raw-cpuid"
+version = "7.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb71f708fe39b2c5e98076204c3cc094ee5a4c12c4cdb119a2b72dc34164f41"
+dependencies = [
+ "bitflags",
+ "cc",
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "rawbytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,12 +2977,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "region"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "root"
+version = "0.1.0"
+dependencies = [
+ "fs_node",
+ "lazy_static",
+ "log",
+ "spin 0.9.2",
+ "x86_64",
 ]
 
 [[package]]
@@ -2499,7 +3043,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -2508,6 +3052,44 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "cc",
+]
+
+[[package]]
+name = "runqueue"
+version = "0.1.0"
+dependencies = [
+ "atomic_linked_list",
+ "irq_safety",
+ "lazy_static",
+ "log",
+ "runqueue_priority",
+ "runqueue_round_robin",
+ "single_simd_task_optimization",
+ "task",
+]
+
+[[package]]
+name = "runqueue_priority"
+version = "0.1.0"
+dependencies = [
+ "atomic_linked_list",
+ "irq_safety",
+ "lazy_static",
+ "log",
+ "single_simd_task_optimization",
+ "task",
+]
+
+[[package]]
+name = "runqueue_round_robin"
+version = "0.1.0"
+dependencies = [
+ "atomic_linked_list",
+ "irq_safety",
+ "lazy_static",
+ "log",
+ "single_simd_task_optimization",
+ "task",
 ]
 
 [[package]]
@@ -2524,11 +3106,20 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.3",
 ]
 
 [[package]]
@@ -2572,16 +3163,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduler"
+version = "0.1.0"
+dependencies = [
+ "apic",
+ "irq_safety",
+ "log",
+ "runqueue",
+ "scheduler_priority",
+ "scheduler_round_robin",
+ "spin 0.9.2",
+ "task",
+]
+
+[[package]]
+name = "scheduler_priority"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "runqueue",
+ "runqueue_priority",
+ "spin 0.9.2",
+ "task",
+]
+
+[[package]]
+name = "scheduler_round_robin"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "runqueue",
+ "runqueue_round_robin",
+ "spin 0.9.2",
+ "task",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scroll"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
+dependencies = [
+ "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2693,6 +3344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "single_simd_task_optimization"
+version = "0.1.0"
+dependencies = [
+ "cfg-if 0.1.10",
+ "log",
+ "task",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +3374,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.0"
+source = "git+https://github.com/theseus-os/spin-rs#8770942ba1790fa536f659e4e07548f0e5da2eb6"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,9 +3401,29 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
+version = "1.1.1"
+source = "git+https://github.com/theseus-os/stable_deref_trait.git?branch=spin#e006c79280042e27c4f16c7d29633eb2273752ee"
+dependencies = [
+ "spin 0.9.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stack"
+version = "0.1.0"
+dependencies = [
+ "kernel_config",
+ "log",
+ "memory",
+ "memory_structs",
+ "page_allocator",
+ "spin 0.9.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2805,7 +3502,7 @@ dependencies = [
  "cap-std",
  "io-lifetimes",
  "rsix",
- "rustc_version",
+ "rustc_version 0.4.0",
  "winapi",
  "winx",
 ]
@@ -2815,6 +3512,27 @@ name = "target-lexicon"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+
+[[package]]
+name = "task"
+version = "0.1.0"
+dependencies = [
+ "context_switch",
+ "crossbeam-utils",
+ "environment",
+ "irq_safety",
+ "kernel_config",
+ "lazy_static",
+ "log",
+ "memory",
+ "mod_mgmt",
+ "root",
+ "spin 0.9.2",
+ "stack",
+ "static_assertions",
+ "tss",
+ "x86_64",
+]
 
 [[package]]
 name = "tempfile"
@@ -2898,12 +3616,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror_core2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6c77692502a14cface45f5cb31b0edcc72cf39c803b95a0b2f4df2814c7898"
+dependencies = [
+ "core2 0.4.0",
+ "thiserror_core2-impl",
+]
+
+[[package]]
+name = "thiserror_core2-impl"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c64183aeaddf559344af98f444cd2ea6685ea0136a59c17587a2c759362e523"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "thread_local_macro"
+version = "0.1.0"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -3030,6 +3776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tss"
+version = "0.1.0"
+dependencies = [
+ "apic",
+ "atomic_linked_list",
+ "lazy_static",
+ "log",
+ "memory",
+ "spin 0.9.2",
+ "x86_64",
+]
+
+[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,13 +3823,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "unsafe-io"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e8cceed59fe60bd092be347343917cbc14b9239536980f09fe34e22c8efbc7"
 dependencies = [
  "io-lifetimes",
- "rustc_version",
+ "rustc_version 0.4.0",
  "winapi",
 ]
 
@@ -3100,6 +3868,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "util"
+version = "0.1.0"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +3879,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
 ]
+
+[[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
 name = "vec_map"
@@ -3121,12 +3899,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "vfs_node"
+version = "0.1.0"
+dependencies = [
+ "fs_node",
+ "log",
+ "memory",
+ "spin 0.9.2",
+ "x86_64",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b06ad3ed06fef1713569d547cdbdb439eafed76341820fb0e0344f29a41945"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wait_queue"
+version = "0.1.0"
+dependencies = [
+ "irq_safety",
+ "log",
+ "scheduler",
+ "task",
 ]
 
 [[package]]
@@ -3355,14 +4175,8 @@ dependencies = [
 name = "wasmparser"
 version = "0.81.0"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
-
-[[package]]
-name = "wasmparser"
-version = "0.81.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
 
 [[package]]
 name = "wasmprinter"
@@ -3371,7 +4185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00ad4a51ba74183137c776ab37dea50b9f71db7454d7b654c2ba69ac5d9b223"
 dependencies = [
  "anyhow",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3387,17 +4201,17 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object 0.26.0",
+ "object 0.26.2",
  "paste",
  "psm",
  "rayon",
- "region",
+ "region 2.2.0",
  "rustc-demangle",
  "serde",
  "target-lexicon",
  "tempfile",
  "wasi-cap-std-sync",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -3487,7 +4301,7 @@ dependencies = [
  "memchr",
  "more-asserts",
  "num_cpus",
- "object 0.26.0",
+ "object 0.26.2",
  "pretty_env_logger",
  "rayon",
  "rsix",
@@ -3497,7 +4311,7 @@ dependencies = [
  "test-programs",
  "tokio",
  "tracing-subscriber",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cranelift",
@@ -3527,10 +4341,10 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object 0.26.0",
+ "object 0.26.2",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -3542,14 +4356,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "cranelift-entity",
  "gimli",
- "hashbrown",
+ "hashbrown 0.11.2",
  "indexmap",
  "log",
- "object 0.26.2",
+ "more-asserts",
+ "object 0.27.1",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.81.0",
+ "wasmparser",
  "wasmtime-types",
 ]
 
@@ -3595,7 +4410,7 @@ dependencies = [
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3614,13 +4429,13 @@ dependencies = [
  "ittapi-rs",
  "log",
  "more-asserts",
- "object 0.26.0",
- "region",
+ "object 0.26.2",
+ "region 2.2.0",
  "rsix",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-runtime",
  "winapi",
@@ -3634,17 +4449,23 @@ dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
+ "core2 0.4.0",
+ "hashbrown 0.11.2",
  "indexmap",
  "lazy_static",
  "libc",
  "log",
  "mach",
- "memoffset",
+ "memoffset 0.6.4",
+ "memory",
  "more-asserts",
+ "mutex_sleep",
+ "path_std",
  "rand 0.8.3",
- "region",
- "rsix",
- "thiserror",
+ "region 3.0.0",
+ "spin 0.9.0",
+ "thiserror_core2",
+ "thread_local_macro",
  "userfaultfd",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -3658,7 +4479,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.81.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3863,6 +4684,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x86_64"
+version = "0.1.2"
+dependencies = [
+ "bit_field",
+ "bitflags",
+ "irq_safety",
+]
+
+[[package]]
+name = "xmas-elf"
+version = "0.6.2"
+source = "git+https://github.com/theseus-os/xmas-elf.git#635d55f6886ae3fe0ec8a78e0bcc1238224c903d"
+dependencies = [
+ "zero",
+]
+
+[[package]]
 name = "xoodyak"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,6 +4728,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa18ba5fbd4933e41ffb440c3fd91f91fe9cdb7310cce3ddfb6648563811de0"
 dependencies = [
  "cmake",
+]
+
+[[package]]
+name = "zero"
+version = "0.1.3"
+source = "git+https://github.com/theseus-os/zero.git#9fc7ff523138a21f40359b706d2d6bf91deafc62"
+
+[[package]]
+name = "zerocopy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0fbc82b82efe24da867ee52e015e58178684bd9dd64c34e66bdf21da2582a9f"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-types",
  "wat",
 ]
@@ -3344,6 +3344,13 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.81.0"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
 
@@ -3354,7 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00ad4a51ba74183137c776ab37dea50b9f71db7454d7b654c2ba69ac5d9b223"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3380,7 +3387,7 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-cap-std-sync",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -3480,7 +3487,7 @@ dependencies = [
  "test-programs",
  "tokio",
  "tracing-subscriber",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cranelift",
@@ -3513,7 +3520,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ",
 ]
 
@@ -3532,7 +3539,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-types",
 ]
 
@@ -3578,7 +3585,7 @@ dependencies = [
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3603,7 +3610,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ",
  "wasmtime-runtime",
  "winapi",
@@ -3641,7 +3648,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.81.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,14 +2393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "path_std"
-version = "0.1.0"
-dependencies = [
- "core2 0.3.3",
- "task",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,6 +4202,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "tempfile",
+ "theseus_std",
  "wasi-cap-std-sync",
  "wasmparser",
  "wasmtime-cache",
@@ -4434,6 +4427,7 @@ dependencies = [
  "rsix",
  "serde",
  "target-lexicon",
+ "theseus_std",
  "thiserror",
  "wasmparser",
  "wasmtime-environ",
@@ -4460,10 +4454,10 @@ dependencies = [
  "memory",
  "more-asserts",
  "mutex_sleep",
- "path_std",
  "rand 0.8.3",
  "region 3.0.0",
  "spin 0.9.0",
+ "theseus_std",
  "thiserror_core2",
  "thread_local_macro",
  "userfaultfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.26.0",
  "rustc-demangle",
 ]
 
@@ -690,7 +690,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-module",
  "log",
- "object",
+ "object 0.26.0",
  "target-lexicon",
 ]
 
@@ -1585,9 +1585,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
@@ -1779,6 +1779,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
 dependencies = [
  "crc32fast",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.26.2"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -3377,7 +3387,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object",
+ "object 0.26.0",
  "paste",
  "psm",
  "rayon",
@@ -3477,7 +3487,7 @@ dependencies = [
  "memchr",
  "more-asserts",
  "num_cpus",
- "object",
+ "object 0.26.0",
  "pretty_env_logger",
  "rayon",
  "rsix",
@@ -3517,7 +3527,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object",
+ "object 0.26.0",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3532,14 +3542,14 @@ dependencies = [
  "cfg-if 1.0.0",
  "cranelift-entity",
  "gimli",
+ "hashbrown",
  "indexmap",
  "log",
- "more-asserts",
- "object",
+ "object 0.26.2",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.81.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.81.0",
  "wasmtime-types",
 ]
 
@@ -3604,7 +3614,7 @@ dependencies = [
  "ittapi-rs",
  "log",
  "more-asserts",
- "object",
+ "object 0.26.0",
  "region",
  "rsix",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ rsix = "0.23.0"
 [dev-dependencies]
 env_logger = "0.8.1"
 filecheck = "0.5.0"
-more-asserts = "0.2.1"
+more-asserts = "0.2.2"
 tempfile = "3.1.0"
 test-programs = { path = "crates/test-programs" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,3 +121,9 @@ harness = false
 [[bench]]
 name = "thread_eager_init"
 harness = false
+
+[patch.crates-io]
+### Theseus-specific patches. 
+### TODO: this can be removed or optionally moved to the top-level Cargo.toml in Theseus.
+wasmparser = { path = "../../libs/wasm-tools/crates/wasmparser" }
+object = { path = "../../libs/object" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,9 +121,3 @@ harness = false
 [[bench]]
 name = "thread_eager_init"
 harness = false
-
-[patch.crates-io]
-### Theseus-specific patches. 
-### TODO: this can be removed or optionally moved to the top-level Cargo.toml in Theseus.
-wasmparser = { path = "../../libs/wasm-tools/crates/wasmparser" }
-object = { path = "../../libs/object" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 cranelift-codegen-shared = { path = "./shared", version = "0.77.0" }
 cranelift-entity = { path = "../entity", version = "0.77.0" }
 cranelift-bforest = { path = "../bforest", version = "0.77.0" }
-hashbrown = { version = "0.9.1", optional = true }
+hashbrown = { version = "0.11.2", optional = true }
 target-lexicon = "0.12"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["entity", "set", "map"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.94", features = ["derive"], optional = true }
+serde = { version = "1.0.94", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [features]
 enable-serde = ["serde"]

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 cranelift-codegen = { path = "../codegen", version = "0.77.0", default-features = false }
 target-lexicon = "0.12"
 log = { version = "0.4.6", default-features = false }
-hashbrown = { version = "0.9.1", optional = true }
+hashbrown = { version = "0.11.2", optional = true }
 smallvec = { version = "1.6.1" }
 
 [features]

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 cranelift-codegen = { path = "../codegen", version = "0.77.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.77.0" }
-hashbrown = { version = "0.9.1", optional = true }
+hashbrown = { version = "0.11.2", optional = true }
 log = { version = "0.4.6", default-features = false }
 anyhow = "1.0"
 

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -17,7 +17,7 @@ cranelift-codegen = { path = "../codegen", version = "0.77.0", default-features 
 cranelift-entity = { path = "../entity", version = "0.77.0" }
 cranelift-frontend = { path = "../frontend", version = "0.77.0", default-features = false }
 wasmtime-types = { path = "../../crates/types", version = "0.30.0" }
-hashbrown = { version = "0.9.1", optional = true }
+hashbrown = { version = "0.11.2", optional = true }
 itertools = "0.10.0"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 [dependencies]
 env_logger = "0.8"
 anyhow = "1.0"
-once_cell = "1.3"
+once_cell = { version = "1.3", default-features = false }
 wasmtime = { path = "../wasmtime", default-features = false, features = ['cranelift'] }
 wasmtime-c-api-macros = { path = "macros" }
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -29,6 +29,6 @@ rsix = "0.23.0"
 [dev-dependencies]
 filetime = "0.2.7"
 lazy_static = "1.3.0"
-more-asserts = "0.2.1"
+more-asserts = "0.2.2"
 pretty_env_logger = "0.4.0"
 tempfile = "3"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -23,7 +23,7 @@ wasmparser = "0.81.0"
 target-lexicon = "0.12"
 gimli = { version = "0.25.0", default-features = false, features = ['read', 'std'] }
 object = { version = "0.26.0", default-features = false, features = ['write'] }
-more-asserts = "0.2.1"
+more-asserts = "0.2.2"
 thiserror = "1.0.4"
 
 [features]

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -22,7 +22,7 @@ log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.2"
 cfg-if = "1.0"
 gimli = { version = "0.25.0", default-features = false, features = ['read'] }
-object = { version = "0.26.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }
+object = { version = "0.27", default-features = false, features = ['read_core', 'write_core', 'elf'] }
 target-lexicon = "0.12"
 hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false }
 
@@ -35,4 +35,4 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["std"]
-std = ["anyhow/std", "thiserror", "wasmparser/std", "wasmtime-types/std"] ## indexmap?
+std = ["anyhow/std", "thiserror", "wasmparser/std", "wasmtime-types/std"] ## indexmap/std?

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -24,7 +24,7 @@ log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.2"
 cfg-if = "1.0"
 gimli = { version = "0.25.0", default-features = false, features = ['read'] }
-object = { version = "0.27", default-features = false, features = ['read_core', 'write_core', 'elf'] }
+object = { version = "0.28", default-features = false, features = ['read_core', 'write_core', 'elf'] }
 target-lexicon = "0.12"
 hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
 

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 anyhow = { version = "1.0", default-features = false }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.77.0" }
 wasmtime-types = { path = "../types", default-features = false, version = "0.30.0" }
-wasmparser = { path = "../../../wasm-tools/crates/wasmparser", default-features = false, version = "0.81" }
+wasmparser = { version = "0.81", default-features = false }
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = { version = "1.0.4", optional = true }
 serde = { version = "1.0.94", default-features = false, features = ["derive"] }
@@ -22,9 +22,13 @@ log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.2"
 cfg-if = "1.0"
 gimli = { version = "0.25.0", default-features = false, features = ['read'] }
-object = { path = "../../../object", version = "0.26.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }
+object = { version = "0.26.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }
 target-lexicon = "0.12"
 hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false }
+
+[patch.crates-io]
+wasmparser = { path = "../../../../libs/wasm-tools/crates/wasmparser" }
+object = { path = "../../../../libs/object" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -11,19 +11,23 @@ keywords = ["webassembly", "wasm"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", default-features = false }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.77.0" }
-wasmtime-types = { path = "../types", version = "0.30.0" }
-wasmparser = "0.81"
+wasmtime-types = { path = "../types", default-features = false, version = "0.30.0" }
+wasmparser = { path = "../../../wasm-tools/crates/wasmparser", default-features = false, version = "0.81" }
 indexmap = { version = "1.0.2", features = ["serde-1"] }
-thiserror = "1.0.4"
-serde = { version = "1.0.94", features = ["derive"] }
+thiserror = { version = "1.0.4", optional = true }
+serde = { version = "1.0.94", default-features = false, features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
-more-asserts = "0.2.1"
 cfg-if = "1.0"
 gimli = { version = "0.25.0", default-features = false, features = ['read'] }
-object = { version = "0.26.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }
+object = { path = "../../../object", version = "0.26.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }
 target-lexicon = "0.12"
+hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false }
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[features]
+default = ["std"]
+std = ["anyhow/std", "thiserror", "wasmparser/std", "wasmtime-types/std"] ## indexmap?

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -17,6 +17,8 @@ wasmtime-types = { path = "../types", default-features = false, version = "0.30.
 wasmparser = { version = "0.81", default-features = false }
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = { version = "1.0.4", optional = true }
+thiserror_core2 = { version = "2.0.0", default-features = false }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 serde = { version = "1.0.94", default-features = false, features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
 more-asserts = "0.2.2"
@@ -31,4 +33,4 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["std"]
-std = ["anyhow/std", "thiserror", "wasmparser/std", "wasmtime-types/std"] ## indexmap/std?
+std = ["anyhow/std", "thiserror", "thiserror_core2/std", "wasmparser/std", "wasmtime-types/std"] ## indexmap/std?

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -24,11 +24,7 @@ cfg-if = "1.0"
 gimli = { version = "0.25.0", default-features = false, features = ['read'] }
 object = { version = "0.27", default-features = false, features = ['read_core', 'write_core', 'elf'] }
 target-lexicon = "0.12"
-hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false }
-
-[patch.crates-io]
-wasmparser = { path = "../../../../libs/wasm-tools/crates/wasmparser" }
-object = { path = "../../../../libs/object" }
+hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -19,6 +19,7 @@ indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = { version = "1.0.4", optional = true }
 serde = { version = "1.0.94", default-features = false, features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
+more-asserts = "0.2.2"
 cfg-if = "1.0"
 gimli = { version = "0.25.0", default-features = false, features = ['read'] }
 object = { path = "../../../object", version = "0.26.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }

--- a/crates/environ/src/address_map.rs
+++ b/crates/environ/src/address_map.rs
@@ -4,8 +4,9 @@
 use object::write::{Object, StandardSegment};
 use object::{Bytes, LittleEndian, SectionKind, U32Bytes};
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
-use std::ops::Range;
+use core::convert::TryFrom;
+use core::ops::Range;
+use alloc::vec::Vec;
 
 /// Single source location to generated address mapping.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -235,6 +235,7 @@ pub trait Compiler: Send + Sync {
 }
 
 /// Value of a configured setting for a [`Compiler`]
+#[derive(Debug)]
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub enum FlagValue {
     /// Name of the value that has been configured for this setting.

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -14,7 +14,6 @@ use core::fmt;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
-use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "std")]

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -9,10 +9,15 @@ use anyhow::Result;
 use object::write::Object;
 use object::{Architecture, BinaryFormat};
 use serde::{Deserialize, Serialize};
-use std::any::Any;
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::fmt;
+use core::any::Any;
+use core::fmt;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
 use thiserror::Error;
 
 /// Information about a function, such as trap information, address map,
@@ -56,18 +61,19 @@ pub struct StackMapInformation {
 }
 
 /// An error while compiling WebAssembly to machine code.
-#[derive(Error, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Error))]
 pub enum CompileError {
     /// A wasm translation error occured.
-    #[error("WebAssembly translation error")]
-    Wasm(#[from] WasmError),
+    #[cfg_attr(feature = "std", error("WebAssembly translation error"))]
+    Wasm(#[cfg_attr(feature = "std", from)] WasmError),
 
     /// A compilation error occured.
-    #[error("Compilation error: {0}")]
+    #[cfg_attr(feature = "std", error("Compilation error: {0}"))]
     Codegen(String),
 
     /// A compilation error occured.
-    #[error("Debug info is not supported with this configuration")]
+    #[cfg_attr(feature = "std", error("Debug info is not supported with this configuration"))]
     DebugInfoNotSupported,
 }
 

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -18,6 +18,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use thiserror::Error;
+#[cfg(not(feature = "std"))]
+use thiserror_core2::Error;
 
 /// Information about a function, such as trap information, address map,
 /// and stack maps.
@@ -60,19 +62,18 @@ pub struct StackMapInformation {
 }
 
 /// An error while compiling WebAssembly to machine code.
-#[derive(Debug)]
-#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Debug, Error)]
 pub enum CompileError {
     /// A wasm translation error occured.
-    #[cfg_attr(feature = "std", error("WebAssembly translation error"))]
-    Wasm(#[cfg_attr(feature = "std", from)] WasmError),
+    #[error("WebAssembly translation error")]
+    Wasm(#[from] WasmError),
 
     /// A compilation error occured.
-    #[cfg_attr(feature = "std", error("Compilation error: {0}"))]
+    #[error("Compilation error: {0}")]
     Codegen(String),
 
     /// A compilation error occured.
-    #[cfg_attr(feature = "std", error("Debug info is not supported with this configuration"))]
+    #[error("Debug info is not supported with this configuration")]
     DebugInfoNotSupported,
 }
 

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -23,6 +23,15 @@
     )
 )]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+type IndexMap<K, V> = indexmap::IndexMap<K, V>;
+#[cfg(not(feature = "std"))]
+type IndexMap<K, V> = indexmap::IndexMap<K, V, hashbrown::hash_map::DefaultHashBuilder>;
+
 mod address_map;
 mod builtin;
 mod compilation;

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1,11 +1,14 @@
 //! Data structures for representing decoded wasm modules.
 
 use crate::{EntityRef, ModuleTranslation, PrimaryMap, Tunables, WASM_PAGE_SIZE};
-use indexmap::IndexMap;
+use crate::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
-use std::ops::Range;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+use core::ops::Range;
 use wasmtime_types::*;
 
 /// Implemenation styles for WebAssembly linear memory.
@@ -36,10 +39,10 @@ impl MemoryStyle {
         } else {
             crate::WASM32_MAX_PAGES
         };
-        let maximum = std::cmp::min(
+        let maximum = core::cmp::min(
             memory.maximum.unwrap_or(absolute_max_pages),
             if tunables.static_memory_bound_is_maximum {
-                std::cmp::min(tunables.static_memory_bound, absolute_max_pages)
+                core::cmp::min(tunables.static_memory_bound, absolute_max_pages)
             } else {
                 absolute_max_pages
             },
@@ -241,10 +244,10 @@ impl ModuleTranslation<'_> {
                 // all zeros.
                 let page = contents
                     .entry(page_index)
-                    .or_insert_with(|| vec![0; page_size as usize]);
+                    .or_insert_with(|| alloc::vec![0; page_size as usize]);
                 let page = &mut page[page_offset..];
 
-                let len = std::cmp::min(data.len(), page.len());
+                let len = core::cmp::min(data.len(), page.len());
                 page[..len].copy_from_slice(&data[..len]);
 
                 page_index += 1;

--- a/crates/environ/src/obj.rs
+++ b/crates/environ/src/obj.rs
@@ -2,6 +2,8 @@
 //! serialization and intermediate format for compiled modules.
 
 use crate::{EntityRef, FuncIndex, SignatureIndex};
+use alloc::format;
+use alloc::string::String;
 
 const FUNCTION_PREFIX: &str = "_wasm_function_";
 const TRAMPOLINE_PREFIX: &str = "_trampoline_";

--- a/crates/environ/src/stack_map.rs
+++ b/crates/environ/src/stack_map.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use serde::{Deserialize, Serialize};
 
 /// A map for determining where live GC references live in a stack frame.

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -1,7 +1,8 @@
 use object::write::{Object, StandardSegment};
 use object::{Bytes, LittleEndian, SectionKind, U32Bytes};
-use std::convert::TryFrom;
-use std::ops::Range;
+use core::convert::TryFrom;
+use core::ops::Range;
+use alloc::vec::Vec;
 
 /// A helper structure to build the custom-encoded section of a wasmtime
 /// compilation image which encodes trap information.

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Tunable parameters for WebAssembly compilation.
+#[derive(Debug)]
 #[derive(Clone, Hash, Serialize, Deserialize)]
 pub struct Tunables {
     /// For static heaps, the size in wasm pages of the heap protected by bounds checking.

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -23,8 +23,7 @@ use crate::{
     BuiltinFunctionIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex,
     GlobalIndex, MemoryIndex, Module, TableIndex, TypeIndex,
 };
-use more_asserts::assert_lt;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// Sentinel value indicating that wasm has been interrupted.
 // Note that this has a bit of an odd definition. See the `insert_stack_check`
@@ -100,7 +99,7 @@ pub struct HostPtr;
 impl PtrSize for HostPtr {
     #[inline]
     fn size(&self) -> u8 {
-        std::mem::size_of::<usize>() as u8
+        core::mem::size_of::<usize>() as u8
     }
 }
 
@@ -591,7 +590,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMSharedSignatureId` index `index`.
     #[inline]
     pub fn vmctx_vmshared_signature_id(&self, index: TypeIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_signature_ids);
+        assert!(index.as_u32() < self.num_signature_ids);
         self.vmctx_signature_ids_begin()
             + index.as_u32() * u32::from(self.size_of_vmshared_signature_index())
     }
@@ -599,7 +598,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMFunctionImport` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import(&self, index: FuncIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_functions);
+        assert!(index.as_u32() < self.num_imported_functions);
         self.vmctx_imported_functions_begin()
             + index.as_u32() * u32::from(self.size_of_vmfunction_import())
     }
@@ -607,7 +606,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMTableImport` index `index`.
     #[inline]
     pub fn vmctx_vmtable_import(&self, index: TableIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_tables);
+        assert!(index.as_u32() < self.num_imported_tables);
         self.vmctx_imported_tables_begin()
             + index.as_u32() * u32::from(self.size_of_vmtable_import())
     }
@@ -615,7 +614,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMMemoryImport` index `index`.
     #[inline]
     pub fn vmctx_vmmemory_import(&self, index: MemoryIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_memories);
+        assert!(index.as_u32() < self.num_imported_memories);
         self.vmctx_imported_memories_begin()
             + index.as_u32() * u32::from(self.size_of_vmmemory_import())
     }
@@ -623,7 +622,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMGlobalImport` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_import(&self, index: GlobalIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_globals);
+        assert!(index.as_u32() < self.num_imported_globals);
         self.vmctx_imported_globals_begin()
             + index.as_u32() * u32::from(self.size_of_vmglobal_import())
     }
@@ -631,21 +630,21 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMTableDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmtable_definition(&self, index: DefinedTableIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_defined_tables);
+        assert!(index.as_u32() < self.num_defined_tables);
         self.vmctx_tables_begin() + index.as_u32() * u32::from(self.size_of_vmtable_definition())
     }
 
     /// Return the offset to `VMMemoryDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmmemory_definition(&self, index: DefinedMemoryIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_defined_memories);
+        assert!(index.as_u32() < self.num_defined_memories);
         self.vmctx_memories_begin() + index.as_u32() * u32::from(self.size_of_vmmemory_definition())
     }
 
     /// Return the offset to the `VMGlobalDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_definition(&self, index: DefinedGlobalIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_defined_globals);
+        assert!(index.as_u32() < self.num_defined_globals);
         self.vmctx_globals_begin() + index.as_u32() * u32::from(self.size_of_vmglobal_definition())
     }
 
@@ -653,8 +652,8 @@ impl<P: PtrSize> VMOffsets<P> {
     /// index (either imported or defined).
     #[inline]
     pub fn vmctx_anyfunc(&self, index: FuncIndex) -> u32 {
-        assert_lt!(
-            index.as_u32(),
+        assert!(
+            index.as_u32() <
             self.num_imported_functions + self.num_defined_functions
         );
         self.vmctx_anyfuncs_begin()

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -23,6 +23,7 @@ use crate::{
     BuiltinFunctionIndex, DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex,
     GlobalIndex, MemoryIndex, Module, TableIndex, TypeIndex,
 };
+use more_asserts::assert_lt;
 use core::convert::TryFrom;
 
 /// Sentinel value indicating that wasm has been interrupted.
@@ -590,7 +591,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMSharedSignatureId` index `index`.
     #[inline]
     pub fn vmctx_vmshared_signature_id(&self, index: TypeIndex) -> u32 {
-        assert!(index.as_u32() < self.num_signature_ids);
+        assert_lt!(index.as_u32(), self.num_signature_ids);
         self.vmctx_signature_ids_begin()
             + index.as_u32() * u32::from(self.size_of_vmshared_signature_index())
     }
@@ -598,7 +599,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMFunctionImport` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import(&self, index: FuncIndex) -> u32 {
-        assert!(index.as_u32() < self.num_imported_functions);
+        assert_lt!(index.as_u32(), self.num_imported_functions);
         self.vmctx_imported_functions_begin()
             + index.as_u32() * u32::from(self.size_of_vmfunction_import())
     }
@@ -606,7 +607,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMTableImport` index `index`.
     #[inline]
     pub fn vmctx_vmtable_import(&self, index: TableIndex) -> u32 {
-        assert!(index.as_u32() < self.num_imported_tables);
+        assert_lt!(index.as_u32(), self.num_imported_tables);
         self.vmctx_imported_tables_begin()
             + index.as_u32() * u32::from(self.size_of_vmtable_import())
     }
@@ -614,7 +615,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMMemoryImport` index `index`.
     #[inline]
     pub fn vmctx_vmmemory_import(&self, index: MemoryIndex) -> u32 {
-        assert!(index.as_u32() < self.num_imported_memories);
+        assert_lt!(index.as_u32(), self.num_imported_memories);
         self.vmctx_imported_memories_begin()
             + index.as_u32() * u32::from(self.size_of_vmmemory_import())
     }
@@ -622,7 +623,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMGlobalImport` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_import(&self, index: GlobalIndex) -> u32 {
-        assert!(index.as_u32() < self.num_imported_globals);
+        assert_lt!(index.as_u32(), self.num_imported_globals);
         self.vmctx_imported_globals_begin()
             + index.as_u32() * u32::from(self.size_of_vmglobal_import())
     }
@@ -630,21 +631,21 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMTableDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmtable_definition(&self, index: DefinedTableIndex) -> u32 {
-        assert!(index.as_u32() < self.num_defined_tables);
+        assert_lt!(index.as_u32(), self.num_defined_tables);
         self.vmctx_tables_begin() + index.as_u32() * u32::from(self.size_of_vmtable_definition())
     }
 
     /// Return the offset to `VMMemoryDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmmemory_definition(&self, index: DefinedMemoryIndex) -> u32 {
-        assert!(index.as_u32() < self.num_defined_memories);
+        assert_lt!(index.as_u32(), self.num_defined_memories);
         self.vmctx_memories_begin() + index.as_u32() * u32::from(self.size_of_vmmemory_definition())
     }
 
     /// Return the offset to the `VMGlobalDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_definition(&self, index: DefinedGlobalIndex) -> u32 {
-        assert!(index.as_u32() < self.num_defined_globals);
+        assert_lt!(index.as_u32(), self.num_defined_globals);
         self.vmctx_globals_begin() + index.as_u32() * u32::from(self.size_of_vmglobal_definition())
     }
 
@@ -652,8 +653,8 @@ impl<P: PtrSize> VMOffsets<P> {
     /// index (either imported or defined).
     #[inline]
     pub fn vmctx_anyfunc(&self, index: FuncIndex) -> u32 {
-        assert!(
-            index.as_u32() <
+        assert_lt!(
+            index.as_u32(),
             self.num_imported_functions + self.num_defined_functions
         );
         self.vmctx_anyfuncs_begin()

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -48,7 +48,7 @@ rsix = { version = "0.23.0", optional = true }
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 thiserror_core2 = { version = "2.0.0", default-features = false }
 theseus_external_unwind_info = { path = "../../../../kernel/external_unwind_info", package = "external_unwind_info" }
-theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
+theseus_std = { path = "../../../../ports/theseus_std" }
 
 [features]
 default = ["std"]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.94", default-features = false, features = ["derive", "a
 addr2line = { version = "0.16.0", default-features = false }
 ittapi-rs = { version = "0.1.5", optional = true  }
 ### Use the newest version of `bincode` from GitHub because it supports no_std
-bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde_alloc", "derive"] }
+bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde", "derive"] }
 ###
 ### NOTE: we *should* be able to include these dependencies here for non-Theseus builds
 ###       but I can't get cargo to build it with the correct features if these are here.

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -17,7 +17,7 @@ region = "2.2.0"
 thiserror = "1.0.4"
 target-lexicon = { version = "0.12.0", default-features = false }
 wasmparser = "0.81"
-more-asserts = "0.2.1"
+more-asserts = "0.2.2"
 anyhow = "1.0"
 cfg-if = "1.0"
 log = "0.4"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { version = "1.0", default-features = false }
 cfg-if = "1.0"
 log = "0.4"
 gimli = { version = "0.25.0", default-features = false, features = ["read"] }
-object = { version = "0.27.1", default-features = false, features = ["read_core", "write_core", "elf"] }
+object = { version = "0.28", default-features = false, features = ["read_core", "write_core", "elf"] }
 serde = { version = "1.0.94", default-features = false, features = ["derive", "alloc"] }
 addr2line = { version = "0.16.0", default-features = false }
 ittapi-rs = { version = "0.1.5", optional = true  }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -11,22 +11,32 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2018"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "0.30.0" }
-wasmtime-runtime = { path = "../runtime", version = "0.30.0" }
-region = "2.2.0"
-thiserror = "1.0.4"
+wasmtime-environ = { path = "../environ", version = "0.30.0", default-features = false }
+wasmtime-runtime = { path = "../runtime", version = "0.30.0", default-features = false }
+region = "3.0.0"
 target-lexicon = { version = "0.12.0", default-features = false }
-wasmparser = "0.81"
+wasmparser = { version = "0.81", default-features = false }
 more-asserts = "0.2.2"
-anyhow = "1.0"
+anyhow = { version = "1.0", default-features = false }
 cfg-if = "1.0"
 log = "0.4"
-gimli = { version = "0.25.0", default-features = false, features = ["std", "read"] }
-object = { version = "0.26.0", default-features = false, features = ["std", "read_core", "elf"] }
-serde = { version = "1.0.94", features = ["derive"] }
+gimli = { version = "0.25.0", default-features = false, features = ["read"] }
+object = { version = "0.27.1", default-features = false, features = ["read_core", "write_core", "elf"] }
+serde = { version = "1.0.94", default-features = false, features = ["derive", "alloc"] }
 addr2line = { version = "0.16.0", default-features = false }
 ittapi-rs = { version = "0.1.5", optional = true  }
-bincode = "1.2.1"
+### Use the newest version of `bincode` from GitHub because it supports no_std
+bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde_alloc", "derive"] }
+###
+### NOTE: we *should* be able to include these dependencies here for non-Theseus builds
+###       but I can't get cargo to build it with the correct features if these are here.
+###       This is likely a bug in cargo's target-specific feature resolution. (?)
+###       Thus, I've made them optional, but included them in the `std` feature below.
+###       Note that this is a hack -- they are not actually optional, they're required.
+###       As such, non-Theseus builds may not work any more on this branch.
+###
+[target.'cfg(not(target_os = "theseus"))'.dependencies]
+thiserror = { version = "1.0.4", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
@@ -34,7 +44,15 @@ winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 rsix = { version = "0.23.0", optional = true }
 
+[target.'cfg(target_os = "theseus")'.dependencies]
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+thiserror_core2 = { version = "2.0.0", default-features = false }
+theseus_external_unwind_info = { path = "../../../../kernel/external_unwind_info", package = "external_unwind_info" }
+theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
+
 [features]
+default = ["std"]
+std = ["thiserror", "wasmtime-environ/std", "wasmtime-runtime/std", "wasmparser/std", "anyhow/std", "gimli/std", "serde/std", "bincode/std"]
 jitdump = ['rsix']
 vtune = ['ittapi-rs']
 

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -142,10 +142,6 @@ impl CodeMemory {
             let text_range = text_offset..text_offset + text_mut.len();
             let mut text_section_readwrite = false;
 
-            log::warn!("mmap: {:#X?}", self.mmap);
-            log::warn!("text_range: {:#X?}", text_range);
-            log::warn!("{:X?}", text_mut);
-
             for (offset, r) in text.relocations() {
                 // If the text section was mapped at readonly we need to make it
                 // briefly read/write here as we apply relocations.

--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -141,6 +141,11 @@ impl CodeMemory {
             let text_offset = ret.text.as_ptr() as usize - ret.mmap.as_ptr() as usize;
             let text_range = text_offset..text_offset + text_mut.len();
             let mut text_section_readwrite = false;
+
+            log::warn!("mmap: {:#X?}", self.mmap);
+            log::warn!("text_range: {:#X?}", text_range);
+            log::warn!("{:X?}", text_mut);
+
             for (offset, r) in text.relocations() {
                 // If the text section was mapped at readonly we need to make it
                 // briefly read/write here as we apply relocations.

--- a/crates/jit/src/debug.rs
+++ b/crates/jit/src/debug.rs
@@ -6,7 +6,8 @@ use object::{
     File, NativeEndian as NE, Object, ObjectSection, ObjectSymbol, RelocationEncoding,
     RelocationKind, RelocationTarget, U64Bytes,
 };
-use std::mem::size_of;
+use core::mem::size_of;
+use alloc::vec::Vec;
 
 pub fn create_gdbjit_image(
     mut bytes: Vec<u8>,
@@ -32,7 +33,8 @@ pub fn create_gdbjit_image(
 
 fn relocate_dwarf_sections(bytes: &mut [u8], code_region: (*const u8, usize)) -> Result<(), Error> {
     let mut relocations = Vec::new();
-    let obj = File::parse(&bytes[..])?;
+    let obj = File::parse(&bytes[..])
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     for section in obj.sections() {
         let section_start = match section.file_range() {
             Some((start, _)) => start,

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -20,6 +20,11 @@
     )
 )]
 
+#![cfg_attr(not(feature = "std"), no_std, feature(core_intrinsics))]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod code_memory;
 mod debug;
 mod instantiate;

--- a/crates/jit/src/link.rs
+++ b/crates/jit/src/link.rs
@@ -2,7 +2,7 @@
 
 use object::read::{Object, Relocation, RelocationTarget};
 use object::{File, NativeEndian as NE, ObjectSymbol, RelocationEncoding, RelocationKind};
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 use wasmtime_runtime::libcalls;
 
 type I32 = object::I32Bytes<NE>;

--- a/crates/jit/src/mmap_vec.rs
+++ b/crates/jit/src/mmap_vec.rs
@@ -19,6 +19,7 @@ use wasmtime_runtime::Mmap;
 ///
 /// An `MmapVec` is an owned value which means that owners have the ability to
 /// get exclusive access to the underlying bytes, enabling mutation.
+#[derive(Debug)]
 pub struct MmapVec {
     mmap: Arc<Mmap>,
     range: Range<usize>,

--- a/crates/jit/src/mmap_vec.rs
+++ b/crates/jit/src/mmap_vec.rs
@@ -4,7 +4,7 @@ use core::ops::{Deref, DerefMut, Range, RangeTo};
 #[cfg(feature = "std")]
 use std::path::Path;
 #[cfg(target_os = "theseus")]
-use theseus_path_std::Path;
+use theseus_std::path::Path;
 use alloc::format;
 use alloc::sync::Arc;
 use wasmtime_runtime::Mmap;

--- a/crates/jit/src/profiling.rs
+++ b/crates/jit/src/profiling.rs
@@ -1,6 +1,12 @@
 use crate::CompiledModule;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
+#[cfg(target_os = "theseus")]
+use core2::error::Error;
+use core::fmt;
+use alloc::format;
+use alloc::string::String;
+#[allow(dead_code)]
 use wasmtime_environ::{DefinedFuncIndex, EntityRef, Module};
 
 cfg_if::cfg_if! {

--- a/crates/jit/src/unwind.rs
+++ b/crates/jit/src/unwind.rs
@@ -8,6 +8,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(unix)] {
         mod systemv;
         pub use self::systemv::*;
+    } else if #[cfg(target_os = "theseus")] {
+        mod theseus;
+        pub use self::theseus::*;  
     } else {
         compile_error!("unsupported target platform for unwind");
     }

--- a/crates/jit/src/unwind/theseus.rs
+++ b/crates/jit/src/unwind/theseus.rs
@@ -1,0 +1,64 @@
+//! Module for registering unwind information with Theseus.
+
+use anyhow::Result;
+use theseus_external_unwind_info::{register_unwind_info, deregister_unwind_info};
+
+/// Represents a registry of function unwind information for Theseus.
+pub struct UnwindRegistration {
+    // Needed to deregister a piece of registered unwind info (see drop handler).
+    text_section_base_address: usize,
+}
+
+impl UnwindRegistration {
+    /// Register a new unwind information section, e.g., `.eh_frame` contents.
+    /// 
+    /// This exposes a C-style API because the rest of wasmtime expects it (for other platforms).
+    /// 
+    /// # Arguments
+    /// * `text_section_base_address`: the base address of the text section
+    /// * `text_section_len`: the length in bytes of the text section
+    /// * `unwind_info`: a pointer to the beginning of the unwind info section (.eh_frame)
+    /// * `unwind_len`: the length in bytes of the unwind info section (.eh_frame)
+    pub unsafe fn new(
+        text_section_base_address: *mut u8,
+        text_section_len: usize,
+        unwind_info: *mut u8,
+        unwind_len: usize,
+    ) -> Result<UnwindRegistration> {
+        log::warn!("registering new unwind info with Theseus:
+            text_section_base_address: {:#X},
+            text_section_len: {:#X},
+            unwind_info: {:#X},
+            unwind_len: {:#X}",
+            text_section_base_address as usize, text_section_len, unwind_info as usize, unwind_len
+        );
+
+        register_unwind_info(
+            text_section_base_address,
+            text_section_len,
+            unwind_info,
+            unwind_len,
+        )
+            .map_err(|_| "failed to register external unwind info with Theseus")
+            .map_err(anyhow::Error::msg)?;
+
+        Ok(UnwindRegistration {
+            text_section_base_address: text_section_base_address as usize,
+        })
+    }
+
+    pub fn section_name() -> &'static str {
+        // Note: this is based on `src/instantiate.rs::wasm_section_name()`
+        ".eh_frame.wasm"
+    }
+}
+
+impl Drop for UnwindRegistration {
+    fn drop(&mut self) {
+        unsafe {
+            if let Err(_e) = deregister_unwind_info(self.text_section_base_address as *mut u8) {
+                log::error!("Failed to deregister Theseus's unwind info for {:#X}", self.text_section_base_address);
+            }
+        }
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -41,9 +41,11 @@ thiserror_core2 = { version = "2.0.0", default-features = false }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rand = { version = "0.8.3", default-features = false, features = ["alloc", "small_rng"] }
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+theseus_catch_unwind = { path = "../../../../kernel/catch_unwind", package = "catch_unwind" }
 thread_local_macro = { path = "../../../../kernel/thread_local_macro" }
 theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
 theseus_memory = { path = "../../../../kernel/memory", package = "memory" }
+theseus_task = { path = "../../../../kernel/memory", package = "task" }
 mutex_sleep = { path = "../../../../kernel/mutex_sleep" }
 spin = { version = "0.9.0", git = "https://github.com/theseus-os/spin-rs" }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -45,7 +45,7 @@ theseus_catch_unwind = { path = "../../../../kernel/catch_unwind", package = "ca
 thread_local_macro = { path = "../../../../kernel/thread_local_macro" }
 theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
 theseus_memory = { path = "../../../../kernel/memory", package = "memory" }
-theseus_task = { path = "../../../../kernel/memory", package = "task" }
+theseus_task = { path = "../../../../kernel/task", package = "task" }
 mutex_sleep = { path = "../../../../kernel/mutex_sleep" }
 spin = { version = "0.9.0", git = "https://github.com/theseus-os/spin-rs" }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,12 +27,15 @@ anyhow = { version = "1.0.38", default-features = false }
 ### NOTE: we *should* be able to include these dependencies here for non-Theseus builds
 ###       but I can't get cargo to build it with the correct features if these are here.
 ###       This is likely a bug in cargo's target-specific feature resolution. (?)
-###       Thus, I've commented them out currently, which means that non-Theseus builds are broken.
+###       Thus, I've made them optional, but included them in the `std` feature below.
+###       Note that this is a hack -- they are not actually optional, they're required.
+###       As such, non-Theseus builds may not work any more on this branch.
 ###
-# [target.'cfg(not(target_os = "theseus"))'.dependencies]
-# thiserror = "1.0.2"
-# lazy_static = "1.4.0"
-# rand = "0.8.3"
+[target.'cfg(not(target_os = "theseus"))'.dependencies]
+thiserror = { version = "1.0.2", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
+rand = { version = "0.8.3", optional = true }
+
 
 [target.'cfg(target_os = "theseus")'.dependencies]
 hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
@@ -70,8 +73,11 @@ cc = "1.0"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = [] # ["std"]
-std = ["anyhow/std", "backtrace/std", "wasmtime-environ/std"]
+default = ["std"]
+std = [
+    "thiserror", "lazy_static", "rand", 
+    "anyhow/std", "backtrace/std", "wasmtime-environ/std",
+]
 
 async = ["wasmtime-fiber"]
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,26 +11,48 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2018"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "0.30.0" }
+wasmtime-environ = { path = "../environ", version = "0.30.0", default-features = false }
 wasmtime-fiber = { path = "../fiber", version = "0.30.0", optional = true }
-region = "2.1.0"
-libc = { version = "0.2.82", default-features = false }
+region = "3.0.0"
+libc = { version = "0.2", default-features = false }
 log = "0.4.8"
 memoffset = "0.6.0"
 indexmap = "1.0.2"
-thiserror = "1.0.4"
-more-asserts = "0.2.1"
+more-asserts = "0.2.2"
 cfg-if = "1.0"
-backtrace = "0.3.61"
-lazy_static = "1.3.0"
-rand = "0.8.3"
-anyhow = "1.0.38"
+backtrace = { version = "0.3.61", default-features = false }
+anyhow = { version = "1.0.38", default-features = false }
+
+###
+### NOTE: we *should* be able to include these dependencies here for non-Theseus builds
+###       but I can't get cargo to build it with the correct features if these are here.
+###       This is likely a bug in cargo's target-specific feature resolution. (?)
+###       Thus, I've commented them out currently, which means that non-Theseus builds are broken.
+###
+# [target.'cfg(not(target_os = "theseus"))'.dependencies]
+# thiserror = "1.0.2"
+# lazy_static = "1.4.0"
+# rand = "0.8.3"
+
+[target.'cfg(target_os = "theseus")'.dependencies]
+hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
+# The `thiserror_core2` crate doesn't actually specify no_std, so we patch it in our top-level Cargo.toml.
+thiserror_core2 = { version = "2.0.0", default-features = false }
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+rand = { version = "0.8.3", default-features = false, features = ["alloc", "small_rng"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+thread_local_macro = { path = "../../../../kernel/thread_local_macro" }
+theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
+theseus_memory = { path = "../../../../kernel/memory", package = "memory" }
+mutex_sleep = { path = "../../../../kernel/mutex_sleep" }
+spin = { version = "0.9.0", git = "https://github.com/theseus-os/spin-rs" }
+
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"
 
-[target.'cfg(unix)'.dependencies]
-rsix = "0.23.2"
+# [target.'cfg(all(not(target_os = "theseus"), unix))'.dependencies]
+# rsix = "0.23.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }
@@ -45,7 +67,8 @@ cc = "1.0"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = []
+default = [] # ["std"]
+std = ["anyhow/std", "backtrace/std", "wasmtime-environ/std"]
 
 async = ["wasmtime-fiber"]
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -46,6 +46,7 @@ thread_local_macro = { path = "../../../../kernel/thread_local_macro" }
 theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
 theseus_memory = { path = "../../../../kernel/memory", package = "memory" }
 theseus_task = { path = "../../../../kernel/task", package = "task" }
+theseus_signal_handler = { path = "../../../../kernel/signal_handler", package = "signal_handler" }
 mutex_sleep = { path = "../../../../kernel/mutex_sleep" }
 spin = { version = "0.9.0", git = "https://github.com/theseus-os/spin-rs" }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -46,7 +46,7 @@ rand = { version = "0.8.3", default-features = false, features = ["alloc", "smal
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 theseus_catch_unwind = { path = "../../../../kernel/catch_unwind", package = "catch_unwind" }
 thread_local_macro = { path = "../../../../kernel/thread_local_macro" }
-theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
+theseus_std = { path = "../../../../ports/theseus_std" }
 theseus_memory = { path = "../../../../kernel/memory", package = "memory" }
 theseus_task = { path = "../../../../kernel/task", package = "task" }
 theseus_signal_handler = { path = "../../../../kernel/signal_handler", package = "signal_handler" }

--- a/crates/runtime/build.rs
+++ b/crates/runtime/build.rs
@@ -2,12 +2,30 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=src/helpers.c");
-    cc::Build::new()
-        .warnings(true)
+    let mut build = cc::Build::new();
+    build.warnings(true)
         .define(
             &format!("CFG_TARGET_OS_{}", env::var("CARGO_CFG_TARGET_OS").unwrap()),
             None,
         )
-        .file("src/helpers.c")
-        .compile("wasmtime-helpers");
+        .file("src/helpers.c");
+    
+        if env::var("CARGO_CFG_TARGET_OS").unwrap().contains("theseus") {
+            build
+                .use_plt(false)
+                .pic(false)
+                // Theseus doesn't yet support the GOT (Global Offset Table),
+                // so we disable usage of the GOT by forcing no PLT and PIC.
+                // In Rust, this is accomplished using `-C relocation-model=static`.
+                .flag("-fno-plt")
+                .flag("-fno-pic")
+                // Theseus currently uses the large code model.
+                .flag("-mcmodel=large") 
+                // Disable stack smashing protection
+                .flag("-fno-stack-protector");
+
+                // eprintln!("Theseus build: {:?}\n{:?}", build, build.get_compiler());
+        }
+
+    build.compile("wasmtime-helpers");
 }

--- a/crates/runtime/src/debug_builtins.rs
+++ b/crates/runtime/src/debug_builtins.rs
@@ -4,7 +4,7 @@ use crate::instance::InstanceHandle;
 use crate::vmcontext::VMContext;
 use wasmtime_environ::{EntityRef, MemoryIndex};
 
-static mut VMCTX_AND_MEMORY: (*mut VMContext, usize) = (std::ptr::null_mut(), 0);
+static mut VMCTX_AND_MEMORY: (*mut VMContext, usize) = (core::ptr::null_mut(), 0);
 
 #[no_mangle]
 pub unsafe extern "C" fn resolve_vmctx_memory(ptr: usize) -> *const u8 {
@@ -20,7 +20,7 @@ pub unsafe extern "C" fn resolve_vmctx_memory(ptr: usize) -> *const u8 {
 
 #[no_mangle]
 pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
-    let ptr = std::ptr::read(p);
+    let ptr = core::ptr::read(p);
     assert!(
         !VMCTX_AND_MEMORY.0.is_null(),
         "must call `__vmctx->set()` before resolving Wasm pointers"
@@ -46,8 +46,8 @@ pub unsafe extern "C" fn set_vmctx_memory(vmctx_ptr: *mut VMContext) {
 // `pub extern "C"`, see rust-lang/rust#25057.
 pub fn ensure_exported() {
     unsafe {
-        std::ptr::read_volatile(resolve_vmctx_memory_ptr as *const u8);
-        std::ptr::read_volatile(set_vmctx_memory as *const u8);
-        std::ptr::read_volatile(resolve_vmctx_memory as *const u8);
+        core::ptr::read_volatile(resolve_vmctx_memory_ptr as *const u8);
+        core::ptr::read_volatile(set_vmctx_memory as *const u8);
+        core::ptr::read_volatile(resolve_vmctx_memory as *const u8);
     }
 }

--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -1,7 +1,7 @@
 use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
 };
-use std::ptr::NonNull;
+use core::ptr::NonNull;
 use wasmtime_environ::{Global, MemoryPlan, TablePlan};
 
 /// The value of an export passed from one instance to another.

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -15,14 +15,14 @@ use crate::{ExportFunction, ExportGlobal, ExportMemory, ExportTable, Store};
 use anyhow::Error;
 use memoffset::offset_of;
 use more_asserts::assert_lt;
-use std::alloc::Layout;
-use std::any::Any;
-use std::convert::TryFrom;
-use std::hash::Hash;
-use std::ops::Range;
-use std::ptr::NonNull;
-use std::sync::Arc;
-use std::{mem, ptr, slice};
+use ::alloc::alloc::Layout;
+use core::any::Any;
+use core::convert::TryFrom;
+use core::hash::Hash;
+use core::ops::Range;
+use core::ptr::NonNull;
+use ::alloc::{boxed::Box, string::String, sync::Arc};
+use core::{mem, ptr, slice};
 use wasmtime_environ::{
     packed_option::ReservedValue, DataIndex, DefinedGlobalIndex, DefinedMemoryIndex,
     DefinedTableIndex, ElemIndex, EntityIndex, EntityRef, EntitySet, FuncIndex, GlobalIndex,

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -9,19 +9,25 @@ use crate::vmcontext::{
 };
 use crate::Store;
 use anyhow::Result;
-use std::alloc;
-use std::any::Any;
-use std::convert::TryFrom;
-use std::marker;
-use std::ptr::{self, NonNull};
-use std::slice;
-use std::sync::Arc;
+use ::alloc::{alloc, borrow::ToOwned};
+use core::any::Any;
+use core::convert::TryFrom;
+use core::marker;
+use core::ptr::{self, NonNull};
+use core::slice;
+use ::alloc::{boxed::Box, string::String, sync::Arc};
+#[cfg(feature = "std")]
 use thiserror::Error;
+#[cfg(target_os = "theseus")]
+use thiserror_core2::Error;
 use wasmtime_environ::{
     DefinedFuncIndex, DefinedMemoryIndex, DefinedTableIndex, EntityRef, EntitySet, FunctionInfo,
     GlobalInit, HostPtr, MemoryInitialization, MemoryInitializer, Module, ModuleType, PrimaryMap,
     SignatureIndex, TableInitializer, TrapCode, VMOffsets, WasmType, WASM_PAGE_SIZE,
 };
+
+#[cfg(target_os = "theseus")]
+use core2;
 
 mod pooling;
 
@@ -660,7 +666,7 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
         let memories = self.create_memories(&req.module, borrow_limiter(&mut limiter))?;
         let tables = Self::create_tables(&req.module, borrow_limiter(&mut limiter))?;
 
-        let host_state = std::mem::replace(&mut req.host_state, Box::new(()));
+        let host_state = core::mem::replace(&mut req.host_state, Box::new(()));
 
         let mut handle = {
             let instance = Instance {

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -18,7 +18,7 @@ use rand::{Rng, SeedableRng};
 use core::convert::TryFrom;
 use core::marker;
 use core::mem;
-use ::alloc::{boxed::Box, format, vec::Vec, sync::Arc};
+use ::alloc::{boxed::Box, vec::Vec, sync::Arc};
 
 #[cfg(not(target_os = "theseus"))]
 use std::sync::Mutex;

--- a/crates/runtime/src/instance/allocator/pooling/theseus.rs
+++ b/crates/runtime/src/instance/allocator/pooling/theseus.rs
@@ -19,7 +19,7 @@ use anyhow::{Context, Result};
 //     Ok(())
 // }
 
-pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn commit_memory_pages(_addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {
         return Ok(());
     }
@@ -32,7 +32,7 @@ pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
     // }
 }
 
-pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_memory_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     Ok(())
 
     // decommit(addr, len, true)
@@ -43,7 +43,7 @@ pub fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     Ok(())
 }
 
-pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub fn decommit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     Ok(())
     // decommit(addr, len, false)
 }

--- a/crates/runtime/src/instance/allocator/pooling/theseus.rs
+++ b/crates/runtime/src/instance/allocator/pooling/theseus.rs
@@ -20,6 +20,7 @@ use anyhow::{Context, Result};
 // }
 
 pub fn commit_memory_pages(_addr: *mut u8, len: usize) -> Result<()> {
+    log::trace!("Note: Theseus commit_memory_pages() does nothing");
     if len == 0 {
         return Ok(());
     }
@@ -33,17 +34,20 @@ pub fn commit_memory_pages(_addr: *mut u8, len: usize) -> Result<()> {
 }
 
 pub fn decommit_memory_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+    log::trace!("Note: Theseus decommit_memory_pages() does nothing");
     Ok(())
 
     // decommit(addr, len, true)
 }
 
 pub fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+    log::trace!("Note: Theseus commit_table_pages() does nothing");
     // A no-op as table pages remain READ|WRITE
     Ok(())
 }
 
 pub fn decommit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+    log::trace!("Note: Theseus decommit_table_pages() does nothing");
     Ok(())
     // decommit(addr, len, false)
 }

--- a/crates/runtime/src/instance/allocator/pooling/theseus.rs
+++ b/crates/runtime/src/instance/allocator/pooling/theseus.rs
@@ -1,0 +1,60 @@
+use anyhow::{Context, Result};
+
+// fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
+//     if len == 0 {
+//         return Ok(());
+//     }
+
+//     unsafe {
+//         if protect {
+//             region::protect(addr, len, region::Protection::NONE)
+//                 .context("failed to protect memory pages")?;
+//         }
+
+//         // On Linux, this is enough to cause the kernel to initialize the pages to 0 on next access
+//         rsix::io::madvise(addr as _, len, rsix::io::Advice::LinuxDontNeed)
+//             .context("madvise failed to decommit: {}")?;
+//     }
+
+//     Ok(())
+// }
+
+pub fn commit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+    if len == 0 {
+        return Ok(());
+    }
+    Ok(())
+
+    // // Just change the protection level to READ|WRITE
+    // unsafe {
+    //     region::protect(addr, len, region::Protection::READ_WRITE)
+    //         .context("failed to make linear memory pages read/write")
+    // }
+}
+
+pub fn decommit_memory_pages(addr: *mut u8, len: usize) -> Result<()> {
+    Ok(())
+
+    // decommit(addr, len, true)
+}
+
+pub fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+    // A no-op as table pages remain READ|WRITE
+    Ok(())
+}
+
+pub fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+    Ok(())
+    // decommit(addr, len, false)
+}
+
+// #[cfg(feature = "async")]
+// pub fn commit_stack_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+//     // A no-op as stack pages remain READ|WRITE
+//     Ok(())
+// }
+
+// #[cfg(feature = "async")]
+// pub fn decommit_stack_pages(addr: *mut u8, len: usize) -> Result<()> {
+//     decommit(addr, len, false)
+// }

--- a/crates/runtime/src/instance/allocator/pooling/theseus.rs
+++ b/crates/runtime/src/instance/allocator/pooling/theseus.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 // fn decommit(addr: *mut u8, len: usize, protect: bool) -> Result<()> {
 //     if len == 0 {

--- a/crates/runtime/src/jit_int.rs
+++ b/crates/runtime/src/jit_int.rs
@@ -3,9 +3,14 @@
 //! or unregister generated object images with debuggers.
 
 use lazy_static::lazy_static;
-use std::pin::Pin;
-use std::ptr;
+use core::pin::Pin;
+use core::ptr;
+use ::alloc::{boxed::Box, vec::Vec};
+
+#[cfg(feature = "std")]
 use std::sync::Mutex;
+#[cfg(target_os = "theseus")]
+use mutex_sleep::MutexSleep as Mutex;
 
 #[repr(C)]
 struct JITCodeEntry {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,7 +20,18 @@
     )
 )]
 
+#![cfg_attr(not(feature = "std"), no_std, feature(core_intrinsics))]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 use std::error::Error;
+#[cfg(not(feature = "std"))]
+use core2::error::Error;
+
+#[cfg(not(feature = "std"))]
+use ::alloc::boxed::Box;
 
 mod export;
 mod externref;

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -2,12 +2,15 @@
 //!
 //! `RuntimeLinearMemory` is to WebAssembly linear memories what `Table` is to WebAssembly tables.
 
+#[cfg(not(feature = "std"))]
+use ::alloc::{boxed::Box, format}; // needed for anyhow macros
+
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;
 use crate::ResourceLimiter;
 use anyhow::{bail, format_err, Error, Result};
 use more_asserts::{assert_ge, assert_le};
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 use wasmtime_environ::{MemoryPlan, MemoryStyle, WASM32_MAX_PAGES, WASM64_MAX_PAGES};
 
 const WASM_PAGE_SIZE: usize = wasmtime_environ::WASM_PAGE_SIZE as usize;

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -3,7 +3,7 @@
 //! `RuntimeLinearMemory` is to WebAssembly linear memories what `Table` is to WebAssembly tables.
 
 #[cfg(not(feature = "std"))]
-use ::alloc::{boxed::Box, format}; // needed for anyhow macros
+use ::alloc::boxed::Box; // needed for anyhow macros
 
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -492,7 +492,7 @@ impl Drop for Mmap {
     #[cfg(target_os = "theseus")]
     fn drop(&mut self) {
         // do nothing, each field will be dropped and the `MappedPages` auto-unmapped
-        log::warn!("Mmap::Drop: Theseus doesn't yet properly unmap its MappedPages and the backing File")
+        log::warn!("Mmap::Drop: Theseus doesn't yet properly unmap its MappedPages and the backing File");
     }
 
     #[cfg(not(any(target_os = "theseus", target_os = "windows")))]

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 #[derive(Debug)]
 pub struct File; 
 #[cfg(target_os = "theseus")]
-use theseus_path_std::Path;
+use theseus_std::path::Path;
 
 
 /// A simple struct consisting of a page-aligned pointer to page-aligned

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -10,7 +10,7 @@ use core::ptr;
 use core::slice;
 
 #[cfg(not(feature = "std"))]
-use ::alloc::{format, vec::Vec};
+use ::alloc::{vec::Vec};
 
 #[cfg(feature = "std")]
 use std::{fs::File, path::Path};

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -13,16 +13,10 @@ use core::slice;
 use ::alloc::{format, vec::Vec};
 
 #[cfg(feature = "std")]
-use std::fs::File;
-#[cfg(feature = "std")]
-use std::path::Path;
+use std::{fs::File, path::Path};
 
 #[cfg(target_os = "theseus")]
-// use theseus_file::File; // TODO: this
-#[derive(Debug)]
-pub struct File; 
-#[cfg(target_os = "theseus")]
-use theseus_std::path::Path;
+use theseus_std::{fs::File, path::Path};
 
 
 /// A simple struct consisting of a page-aligned pointer to page-aligned
@@ -37,7 +31,7 @@ pub struct Mmap {
     len: usize,
     file: Option<File>,
     #[cfg(target_os = "theseus")]
-    mapping: theseus_memory::MappedPages,
+    _mapping: theseus_memory::MappedPages,
 }
 
 impl Mmap {
@@ -52,7 +46,7 @@ impl Mmap {
             len: 0,
             file: None,
             #[cfg(target_os = "theseus")]
-            mapping: theseus_memory::MappedPages::empty(),
+            _mapping: theseus_memory::MappedPages::empty(),
         }
     }
 
@@ -197,7 +191,7 @@ impl Mmap {
             ptr: mp.start_address().value(),
             len: mapping_size,
             file: None,
-            mapping: mp,
+            _mapping: mp,
         })
     }
 
@@ -476,6 +470,7 @@ impl Drop for Mmap {
     #[cfg(target_os = "theseus")]
     fn drop(&mut self) {
         // do nothing, each field will be dropped and the `MappedPages` auto-unmapped
+        todo!("Mmap::Drop: Theseus doesn't yet properly unmap its MappedPages and the backing File")
     }
 
     #[cfg(not(any(target_os = "theseus", target_os = "windows")))]

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -1,16 +1,23 @@
 //! Low-level abstraction for allocating and managing zero-filled pages
 //! of memory.
-
+#[cfg(any(unix, windows))]
 use anyhow::anyhow;
-use anyhow::{Context, Result};
+
+use anyhow::Result;
 use more_asserts::assert_le;
+
+#[cfg(any(unix, windows))]
 use core::convert::TryFrom;
+
 use core::ops::Range;
+
+#[cfg(any(unix, windows))]
 use core::ptr;
+
 use core::slice;
 
 #[cfg(not(feature = "std"))]
-use ::alloc::{vec::Vec};
+use ::alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 use std::{fs::File, path::Path};
@@ -164,6 +171,7 @@ impl Mmap {
 
         #[cfg(target_os = "theseus")]
         {
+            let _path = path;
             todo!("Mmap::from_file() is unimplemented for Theseus");
         }
 
@@ -448,6 +456,8 @@ impl Mmap {
         // Theseus doesn't currently allow one to remap only *part* of a `MappedPages` region,
         // so we just remap the entire region at once.
         #[cfg(target_os = "theseus")] {
+            let _base = base;
+            let _len = len;
             return self.theseus_mp.lock().remap(
                 &mut theseus_memory::get_kernel_mmi_ref().unwrap().lock().page_table,
                 theseus_memory::EntryFlags::PRESENT | theseus_memory::EntryFlags::WRITABLE, // read/write

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -2,12 +2,15 @@
 //!
 //! `Table` is to WebAssembly tables what `LinearMemory` is to WebAssembly linear memories.
 
+#[cfg(not(feature = "std"))]
+use ::alloc::{vec, vec::Vec, format};
+
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMTableDefinition};
 use crate::{ResourceLimiter, Trap, VMExternRef};
 use anyhow::{bail, Result};
-use std::convert::{TryFrom, TryInto};
-use std::ops::Range;
-use std::ptr;
+use core::convert::{TryFrom, TryInto};
+use core::ops::Range;
+use core::ptr;
 use wasmtime_environ::{TablePlan, TrapCode, WasmType};
 
 /// An element going into or coming out of a table.

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -3,7 +3,7 @@
 //! `Table` is to WebAssembly tables what `LinearMemory` is to WebAssembly linear memories.
 
 #[cfg(not(feature = "std"))]
-use ::alloc::{vec, vec::Vec, format};
+use ::alloc::{vec, vec::Vec};
 
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMTableDefinition};
 use crate::{ResourceLimiter, Trap, VMExternRef};

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -19,6 +19,8 @@ use spin::Once;
 
 #[cfg(target_os = "theseus")]
 use thread_local_macro::thread_local;
+#[cfg(target_os = "theseus")]
+use theseus_task::{KillReason, PanicInfoOwned};
 
 pub use self::tls::{tls_eager_initialize, TlsRestore};
 
@@ -265,7 +267,9 @@ impl CallThreadState {
                 #[cfg(feature = "std")]
                 std::panic::resume_unwind(panic);
                 #[cfg(target_os = "theseus")]
-                panic!("TODO: Need support for `resume_unwind` in Theseus");
+                theseus_catch_unwind::resume_unwind(
+                   KillReason::Panic(PanicInfoOwned::from_payload(panic))
+                );
             }
         })
     }

--- a/crates/runtime/src/traphandlers/theseus.rs
+++ b/crates/runtime/src/traphandlers/theseus.rs
@@ -1,0 +1,21 @@
+use crate::traphandlers::Trap;
+use ::alloc::boxed::Box;
+
+// TODO: temporary fix to satisfy libc dependencies
+mod libc {
+    pub(crate) type c_int = u32;
+    pub(crate) type siginfo_t = usize;
+    pub(crate) type c_void = usize;
+}
+
+/// Function which may handle custom signals while processing traps.
+pub type SignalHandler<'a> =
+    dyn Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool + Send + Sync + 'a;
+
+pub unsafe fn platform_init() {
+    panic!("TODO: implement traphandlers::theseus::platform_init()");
+}
+
+pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
+    panic!("TODO: implement traphandlers::theseus::lazy_per_thread_init()");
+}

--- a/crates/runtime/src/traphandlers/theseus.rs
+++ b/crates/runtime/src/traphandlers/theseus.rs
@@ -1,21 +1,78 @@
-use crate::traphandlers::Trap;
+use crate::traphandlers::{tls, wasmtime_longjmp, Trap};
 use ::alloc::boxed::Box;
+use theseus_signal_handler::{register_signal_handler, SignalContext, Signal};
 
-// TODO: temporary fix to satisfy libc dependencies
-mod libc {
-    pub(crate) type c_int = u32;
-    pub(crate) type siginfo_t = usize;
-    pub(crate) type c_void = usize;
-}
 
 /// Function which may handle custom signals while processing traps.
 pub type SignalHandler<'a> =
-    dyn Fn(libc::c_int, *const libc::siginfo_t, *const libc::c_void) -> bool + Send + Sync + 'a;
+    dyn Fn(&SignalContext) -> bool + Send + Sync + 'a;
 
+/// This isn't really unsafe in Theseus, but the rest of wasmtime expects it to be,
+/// so we keep it an unsafe fn to match other platforms.
 pub unsafe fn platform_init() {
-    panic!("TODO: implement traphandlers::theseus::platform_init()");
+    platform_init_internal();
+}
+
+fn platform_init_internal() {
+    // Register the `trap_handler` function as a Theseus signal handler by default.
+    register_signal_handler(Signal::InvalidAddress, Box::new(trap_handler))
+        .expect("platform_init(): failed to register Signal::InvalidAddress handler");
+    register_signal_handler(Signal::IllegalInstruction, Box::new(trap_handler))
+        .expect("platform_init(): failed to register Signal::IllegalInstruction handler");
+    register_signal_handler(Signal::BusError, Box::new(trap_handler))
+        .expect("platform_init(): failed to register Signal::BusError handler");
+    register_signal_handler(Signal::ArithmeticError, Box::new(trap_handler))
+        .expect("platform_init(): failed to register Signal::ArithmeticError handler");
+}
+
+/// The default signal handler for wasmtime on Theseus.
+/// 
+/// Note: much of this was borrowed from `traphandlers/unix.rs`
+fn trap_handler(signal_context: &SignalContext) -> Result<(), ()> {
+    
+    let handled: bool = tls::with(|info| {
+        // If no wasm code is executing, we don't handle this as a wasm trap.
+        let info = match info {
+            Some(info) => info,
+            None => return false,
+        };
+
+        // If we hit an exception while handling a previous trap, that's
+        // quite bad, so bail out and let the system handle this
+        // recursive segfault.
+        //
+        // Otherwise flag ourselves as handling a trap, do the trap
+        // handling, and reset our trap handling flag. Then we figure
+        // out what to do based on the result of the trap handling.
+        let pc = signal_context.instruction_pointer.value() as *const u8;
+        let jmp_buf = info.jmp_buf_if_trap(pc, |handler| handler(signal_context));
+
+        // Figure out what to do based on the result of this handling of
+        // the trap. Note that our sentinel value of 1 means that the
+        // exception was handled by a custom exception handler, so we
+        // keep executing.
+        if jmp_buf.is_null() {
+            return false;
+        }
+        if jmp_buf as usize == 1 {
+            return true;
+        }
+        info.capture_backtrace(pc);
+        
+        unsafe { wasmtime_longjmp(jmp_buf) }
+    }); // end of tls::with() closure
+
+    if handled {
+        // indicates we handled this trap, and the task can continue executing.
+        Ok(())
+    } else {
+        // we didn't handle this trap, so we'll allow the Theseus system 
+        // to continue on to its default action of likely killing the task.
+        Err(())
+    }
 }
 
 pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
-    panic!("TODO: implement traphandlers::theseus::lazy_per_thread_init()");
+    // Unused on Theseus
+    Ok(())
 }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -3,12 +3,12 @@
 
 use crate::externref::VMExternRef;
 use crate::instance::Instance;
-use std::any::Any;
-use std::cell::UnsafeCell;
-use std::marker;
-use std::ptr::NonNull;
-use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-use std::u32;
+use core::any::Any;
+use core::cell::UnsafeCell;
+use core::marker;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use core::u32;
 use wasmtime_environ::BuiltinFunctionIndex;
 
 /// An imported function.

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 libc = "0.2.65"
 wasi = "0.10.2"
-more-asserts = "0.2.1"
+more-asserts = "0.2.2"
 lazy_static = "1.4"
 
 # This crate is built with the wasm32-wasi target, so it's separate

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -12,4 +12,8 @@ edition = "2018"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.77.0", features = ['enable-serde'] }
 serde = { version = "1.0.94", features = ["derive"] }
 thiserror = "1.0.4"
-wasmparser = { version = "0.81", default-features = false }
+wasmparser = { path = "../../../wasm-tools/crates/wasmparser", default-features = false } ### Theseus
+
+[features]
+default = ["std"]
+std = []

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 
 [dependencies]
 cranelift-entity = { path = "../../cranelift/entity", version = "0.77.0", features = ['enable-serde'] }
-serde = { version = "1.0.94", features = ["derive"] }
-thiserror = "1.0.4"
+serde = { version = "1.0.94", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.4", optional = true }
 wasmparser = { path = "../../../wasm-tools/crates/wasmparser", default-features = false } ### Theseus
 
 [features]
 default = ["std"]
-std = []
+std = ["thiserror"]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -16,4 +16,4 @@ wasmparser = { path = "../../../wasm-tools/crates/wasmparser", default-features 
 
 [features]
 default = ["std"]
-std = ["thiserror"]
+std = ["wasmparser/std", "thiserror"]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -14,9 +14,6 @@ serde = { version = "1.0.94", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.4", optional = true }
 wasmparser = { version = "0.81", default-features = false }
 
-[patch.crates-io]
-wasmparser = { path = "../../../../libs/wasm-tools/crates/wasmparser" } ### Theseus
-
 [features]
 default = ["std"]
 std = ["wasmparser/std", "thiserror"]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -12,7 +12,10 @@ edition = "2018"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.77.0", features = ['enable-serde'] }
 serde = { version = "1.0.94", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.4", optional = true }
-wasmparser = { path = "../../../wasm-tools/crates/wasmparser", default-features = false } ### Theseus
+wasmparser = { version = "0.81", default-features = false }
+
+[patch.crates-io]
+wasmparser = { path = "../../../../libs/wasm-tools/crates/wasmparser" } ### Theseus
 
 [features]
 default = ["std"]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -12,8 +12,10 @@ edition = "2018"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.77.0", features = ['enable-serde'] }
 serde = { version = "1.0.94", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.4", optional = true }
+thiserror_core2 = { version = "2.0.0", default-features = false }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 wasmparser = { version = "0.81", default-features = false }
 
 [features]
 default = ["std"]
-std = ["wasmparser/std", "thiserror"]
+std = ["wasmparser/std", "thiserror", "thiserror_core2/std"]

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -1,19 +1,22 @@
 #[cfg(feature = "std")]
 use thiserror::Error;
+#[cfg(not(feature = "std"))]
+use thiserror_core2::Error;
+#[cfg(not(feature = "std"))]
+use core2;
 use alloc::string::String;
 
 /// A WebAssembly translation error.
 ///
 /// When a WebAssembly function can't be translated, one of these error codes will be returned
 /// to describe the failure.
-#[derive(Debug)]
-#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Debug, Error)]
 pub enum WasmError {
     /// The input WebAssembly code is invalid.
     ///
     /// This error code is used by a WebAssembly translator when it encounters invalid WebAssembly
     /// code. This should never happen for validated WebAssembly code.
-    #[cfg_attr(feature = "std", error("Invalid input WebAssembly code at offset {offset}: {message}"))]
+    #[error("Invalid input WebAssembly code at offset {offset}: {message}")]
     InvalidWebAssembly {
         /// A string describing the validation error.
         message: String,
@@ -24,7 +27,7 @@ pub enum WasmError {
     /// A feature used by the WebAssembly code is not supported by the embedding environment.
     ///
     /// Embedding environments may have their own limitations and feature restrictions.
-    #[cfg_attr(feature = "std", error("Unsupported feature: {0}"))]
+    #[error("Unsupported feature: {0}")]
     Unsupported(String),
 
     /// An implementation limit was exceeded.
@@ -33,11 +36,11 @@ pub enum WasmError {
     /// limits][limits] that cause compilation to fail when they are exceeded.
     ///
     /// [limits]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/docs/ir.md#implementation-limits
-    #[cfg_attr(feature = "std", error("Implementation limit exceeded"))]
+    #[error("Implementation limit exceeded")]
     ImplLimitExceeded,
 
     /// Any user-defined error.
-    #[cfg_attr(feature = "std", error("User error: {0}"))]
+    #[error("User error: {0}")]
     User(String),
 }
 

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -1,16 +1,19 @@
+#[cfg(feature = "std")]
 use thiserror::Error;
+use alloc::string::String;
 
 /// A WebAssembly translation error.
 ///
 /// When a WebAssembly function can't be translated, one of these error codes will be returned
 /// to describe the failure.
-#[derive(Error, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Error))]
 pub enum WasmError {
     /// The input WebAssembly code is invalid.
     ///
     /// This error code is used by a WebAssembly translator when it encounters invalid WebAssembly
     /// code. This should never happen for validated WebAssembly code.
-    #[error("Invalid input WebAssembly code at offset {offset}: {message}")]
+    #[cfg_attr(feature = "std", error("Invalid input WebAssembly code at offset {offset}: {message}"))]
     InvalidWebAssembly {
         /// A string describing the validation error.
         message: String,
@@ -21,7 +24,7 @@ pub enum WasmError {
     /// A feature used by the WebAssembly code is not supported by the embedding environment.
     ///
     /// Embedding environments may have their own limitations and feature restrictions.
-    #[error("Unsupported feature: {0}")]
+    #[cfg_attr(feature = "std", error("Unsupported feature: {0}"))]
     Unsupported(String),
 
     /// An implementation limit was exceeded.
@@ -30,11 +33,11 @@ pub enum WasmError {
     /// limits][limits] that cause compilation to fail when they are exceeded.
     ///
     /// [limits]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/docs/ir.md#implementation-limits
-    #[error("Implementation limit exceeded")]
+    #[cfg_attr(feature = "std", error("Implementation limit exceeded"))]
     ImplLimitExceeded,
 
     /// Any user-defined error.
-    #[error("User error: {0}")]
+    #[cfg_attr(feature = "std", error("User error: {0}"))]
     User(String),
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,13 +1,22 @@
 //! Internal dependency of Wasmtime and Cranelift that defines types for
 //! WebAssembly.
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::string::ToString;
 pub use wasmparser;
 
 use cranelift_entity::entity_impl;
 
 use serde::{Deserialize, Serialize};
-use std::convert::{TryFrom, TryInto};
-use std::fmt;
+use core::convert::{TryFrom, TryInto};
+use core::fmt;
 
 mod error;
 pub use error::*;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,10 +1,7 @@
 //! Internal dependency of Wasmtime and Cranelift that defines types for
 //! WebAssembly.
 
-#![no_std]
-
-#[cfg(feature = "std")]
-extern crate std;
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -37,7 +37,7 @@ indexmap = "1.6"
 paste = "1.0.3"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 rayon = { version = "1.0", optional = true }
-object = { version = "0.27.1", default-features = false, features = ['read_core', 'elf'] }
+object = { version = "0.28", default-features = false, features = ['read_core', 'elf'] }
 hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
 

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4.8"
 wat = { version = "1.0.36", optional = true }
 serde = { version = "1.0.94", default-features = false, features = ["derive", "alloc"] }
 ### Use the newest version of `bincode` from GitHub because it supports no_std
-bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde_alloc", "derive"] }
+bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde", "derive"] }
 indexmap = "1.6"
 paste = "1.0.3"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -44,7 +44,7 @@ core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nig
 
 [target.'cfg(target_os = "theseus")'.dependencies]
 theseus_mutex = { path = "../../../../kernel/mutex_sleep", package = "mutex_sleep" }
-theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
+theseus_std = { path = "../../../../ports/theseus_std" }
 theseus_catch_unwind = { path = "../../../../kernel/catch_unwind", package = "catch_unwind" }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -35,12 +35,14 @@ serde = { version = "1.0.94", default-features = false, features = ["derive", "a
 bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde_alloc", "derive"] }
 indexmap = "1.6"
 paste = "1.0.3"
-psm = "0.1.11"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 rayon = { version = "1.0", optional = true }
 object = { version = "0.27.1", default-features = false, features = ['read_core', 'elf'] }
 hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
 core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+
+[target.'cfg(not(target_os = "theseus"))'.dependencies]
+psm = "0.1.11"  ## Not used in Theseus
 
 [target.'cfg(target_os = "theseus")'.dependencies]
 theseus_mutex = { path = "../../../../kernel/mutex_sleep", package = "mutex_sleep" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -13,31 +13,39 @@ edition = "2018"
 rustdoc-args = ["--cfg", "nightlydoc"]
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime", version = "0.30.0" }
-wasmtime-environ = { path = "../environ", version = "0.30.0" }
-wasmtime-jit = { path = "../jit", version = "0.30.0" }
+wasmtime-runtime = { path = "../runtime", version = "0.30.0", default-features = false }
+wasmtime-environ = { path = "../environ", version = "0.30.0", default-features = false }
+wasmtime-jit = { path = "../jit", version = "0.30.0", default-features = false }
 wasmtime-cache = { path = "../cache", version = "0.30.0", optional = true }
 wasmtime-fiber = { path = "../fiber", version = "0.30.0", optional = true }
 wasmtime-cranelift = { path = "../cranelift", version = "0.30.0", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
-wasmparser = "0.81"
-anyhow = "1.0.19"
-region = "2.2.0"
-libc = "0.2"
+wasmparser = { version = "0.81", default-features = false }
+anyhow = { version = "1.0.19", default-features = false }
+region = "3.0.0"
+libc = { version = "0.2", default-features = false }
 cfg-if = "1.0"
-backtrace = "0.3.61"
+backtrace = { version = "0.3.61", default-features = false }
 rustc-demangle = "0.1.16"
-cpp_demangle = "0.3.2"
+cpp_demangle = { version = "0.3.2", default-features = false, features = ["alloc"] }
 log = "0.4.8"
 wat = { version = "1.0.36", optional = true }
-serde = { version = "1.0.94", features = ["derive"] }
-bincode = "1.2.1"
+serde = { version = "1.0.94", default-features = false, features = ["derive", "alloc"] }
+### Use the newest version of `bincode` from GitHub because it supports no_std
+bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "serde_alloc", "derive"] }
 indexmap = "1.6"
 paste = "1.0.3"
 psm = "0.1.11"
-lazy_static = "1.4"
+lazy_static = { version = "1.4", features = ["spin_no_std"] }
 rayon = { version = "1.0", optional = true }
-object = { version = "0.26", default-features = false, features = ['read_core', 'elf'] }
+object = { version = "0.27.1", default-features = false, features = ['read_core', 'elf'] }
+hashbrown = { version = "0.11.2", features = ["ahash"], default-features = false }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc", "nightly"] }
+
+[target.'cfg(target_os = "theseus")'.dependencies]
+theseus_mutex = { path = "../../../../kernel/mutex_sleep", package = "mutex_sleep" }
+theseus_path_std = { path = "../../../../ports/path_std", package = "path_std" }
+theseus_catch_unwind = { path = "../../../../kernel/catch_unwind", package = "catch_unwind" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.7"
@@ -51,7 +59,9 @@ wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ['async', 'cache', 'wat', 'jitdump', 'parallel-compilation', 'cranelift']
+default = ['std', 'async', 'cache', 'wat', 'jitdump', 'parallel-compilation', 'cranelift']
+std = ["anyhow/std", "backtrace/std", "wasmtime-runtime/std", "wasmtime-environ/std", "wasmparser/std", "cpp_demangle/std", "bincode/std", "serde/std"]
+
 
 # An on-by-default feature enabling runtime compilation of WebAssembly modules
 # with the Cranelift compiler. Cranelift is the default compilation backend of

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -331,6 +331,7 @@ impl Default for InstanceAllocationStrategy {
 }
 
 #[derive(Clone)]
+#[derive(Debug)]
 /// Configure the strategy used for versioning in serializing and deserializing [`crate::Module`].
 pub enum ModuleVersionStrategy {
     /// Use the wasmtime crate's Cargo package version.
@@ -546,7 +547,8 @@ impl Config {
             }
             #[cfg(not(feature = "std"))]
             WasmBacktraceDetails::Environment => {
-                todo!("Theseus doesn't support WasmBacktraceDetails::Environment");
+                self.wasm_backtrace_details_env_used = true;
+                false // TODO: Theseus always disables wasm backtrace details (WasmBacktraceDetails)
             }
         };
         self

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -3,7 +3,7 @@ use crate::{Config, Trap};
 use anyhow::Result;
 #[cfg(feature = "parallel-compilation")]
 use rayon::prelude::*;
-use std::sync::Arc;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 #[cfg(feature = "cache")]
 use wasmtime_cache::CacheConfig;
 use wasmtime_runtime::{debug_builtins, InstanceAllocator};

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -5,8 +5,8 @@ use crate::{
     Mutability, TableType, Trap, Val, ValType,
 };
 use anyhow::{anyhow, bail, Result};
-use std::mem;
-use std::ptr;
+use core::mem;
+use core::ptr;
 use wasmtime_runtime::{self as runtime, InstanceHandle};
 
 // Externals
@@ -443,7 +443,8 @@ impl Table {
             let table = Table::from_wasmtime_table(wasmtime_export, store);
             (*table.wasmtime_table(store))
                 .fill(0, init, ty.minimum())
-                .map_err(Trap::from_runtime)?;
+                .map_err(Trap::from_runtime)
+                .map_err(anyhow::Error::msg)?;
 
             Ok(table)
         }
@@ -590,7 +591,8 @@ impl Table {
         let src = src_table.wasmtime_table(store);
         unsafe {
             runtime::Table::copy(dst, src, dst_index, src_index, len)
-                .map_err(Trap::from_runtime)?;
+                .map_err(Trap::from_runtime)
+                .map_err(anyhow::Error::msg)?;
         }
         Ok(())
     }
@@ -618,7 +620,8 @@ impl Table {
 
         let table = self.wasmtime_table(store);
         unsafe {
-            (*table).fill(dst, val, len).map_err(Trap::from_runtime)?;
+            (*table).fill(dst, val, len).map_err(Trap::from_runtime)
+                .map_err(anyhow::Error::msg)?;
         }
 
         Ok(())

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1875,7 +1875,7 @@ macro_rules! impl_into_func {
                         let func = &*(state as *const _ as *const F);
 
                         let ret = {
-                            let closure = || {
+                            let mut closure = || {
                                 if let Err(trap) = caller.store.0.call_hook(CallHook::CallingHost) {
                                     return R::fallible_from_trap(trap);
                                 }

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -2,9 +2,9 @@ use super::{invoke_wasm_and_catch_traps, HostAbi};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{AsContextMut, ExternRef, Func, StoreContextMut, Trap, ValType};
 use anyhow::{bail, Result};
-use std::marker;
-use std::mem::{self, MaybeUninit};
-use std::ptr;
+use core::marker;
+use core::mem::{self, MaybeUninit};
+use core::ptr;
 use wasmtime_runtime::{VMContext, VMFunctionBody};
 
 /// A statically typed WebAssembly function.

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -371,6 +371,14 @@
 #![cfg_attr(nightlydoc, feature(doc_cfg))]
 #![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#![cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(all(test, not(feature = "std")))]
+extern crate std;
+
 #[macro_use]
 mod func;
 

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -372,6 +372,7 @@
 #![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(target_os = "theseus", feature(naked_functions))]
 
 #![cfg(not(feature = "std"))]
 extern crate alloc;

--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -2,8 +2,9 @@ use crate::store::{StoreData, StoreOpaque, Stored};
 use crate::trampoline::generate_memory_export;
 use crate::{AsContext, AsContextMut, MemoryType, StoreContext, StoreContextMut};
 use anyhow::{bail, Result};
-use std::convert::TryFrom;
-use std::slice;
+use core::convert::TryFrom;
+use core::slice;
+use alloc::{boxed::Box, string::String};
 
 /// Error for out of bounds [`Memory`] access.
 #[derive(Debug)]
@@ -13,13 +14,16 @@ pub struct MemoryAccessError {
     _private: (),
 }
 
-impl std::fmt::Display for MemoryAccessError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for MemoryAccessError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "out of bounds memory access")
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MemoryAccessError {}
+#[cfg(not(feature = "std"))]
+impl core2::error::Error for MemoryAccessError {}
 
 /// A WebAssembly linear memory.
 ///

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -4,12 +4,15 @@ use crate::{
 };
 use crate::{Engine, ModuleType};
 use anyhow::{bail, Context, Result};
+#[cfg(feature = "std")]
 use std::fs;
+#[cfg(target_os = "theseus")]
+use theseus_std::fs;
 use core::mem;
 #[cfg(feature = "std")]
 use std::path::Path;
 #[cfg(target_os = "theseus")]
-use theseus_path_std::Path;
+use theseus_std::path::Path;
 use alloc::{sync::Arc, vec::Vec};
 use wasmparser::{Parser, ValidPayload, Validator};
 use wasmtime_environ::{ModuleEnvironment, ModuleIndex, PrimaryMap};

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -1,10 +1,16 @@
 //! Implements a registry of modules for a store.
 
 use crate::{signatures::SignatureCollection, Module};
+#[cfg(feature = "std")]
 use std::{
     collections::BTreeMap,
     sync::{Arc, RwLock},
 };
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, string::{String, ToString}, sync::Arc, vec::Vec};
+#[cfg(target_os = "theseus")]
+use theseus_mutex::RwLockSleep as RwLock;
+
 use wasmtime_environ::{EntityRef, FilePos, StackMap, TrapCode};
 use wasmtime_jit::CompiledModule;
 use wasmtime_runtime::{ModuleInfo, VMCallerCheckedAnyfunc, VMTrampoline};

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -58,7 +58,7 @@ use core::convert::TryFrom;
 #[cfg(feature = "std")]
 use std::path::Path;
 #[cfg(target_os = "theseus")]
-use theseus_path_std::Path;
+use theseus_std::path::Path;
 use core::str::FromStr;
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 use wasmtime_environ::{Compiler, FlagValue, Tunables};
@@ -373,7 +373,7 @@ impl<'a> SerializedModule<'a> {
         #[cfg(feature = "std")]
         bincode::serialize_into(&mut ret, &self.metadata)?;
         #[cfg(not(feature = "std"))] {
-            let metadata_bytes = bincode::serde::encode_to_vec(&self.metadata, bincode::config::legacy())
+            let mut metadata_bytes = bincode::serde::encode_to_vec(&self.metadata, bincode::config::legacy())
                 .map_err(|e| anyhow!("{}", e))?;
             ret.append(&mut metadata_bytes);
         }

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -666,7 +666,7 @@ impl<'a> SerializedModule<'a> {
             bulk_memory,
             module_linking,
             simd,
-            relaxed_simd,
+            relaxed_simd: _,
             threads,
             tail_call,
             deterministic_only,

--- a/crates/wasmtime/src/ref.rs
+++ b/crates/wasmtime/src/ref.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use crate::AsContextMut;
-use std::any::Any;
+use core::any::Any;
 use wasmtime_runtime::VMExternRef;
 
 /// Represents an opaque reference to any data within WebAssembly.

--- a/crates/wasmtime/src/store/data.rs
+++ b/crates/wasmtime/src/store/data.rs
@@ -1,10 +1,11 @@
 use crate::store::StoreOpaque;
 use crate::{StoreContext, StoreContextMut};
-use std::fmt;
-use std::marker;
-use std::num::NonZeroU64;
-use std::ops::{Index, IndexMut};
-use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
+use core::fmt;
+use core::marker;
+use core::num::NonZeroU64;
+use core::ops::{Index, IndexMut};
+use core::sync::atomic::{AtomicU64, Ordering::SeqCst};
+use alloc::vec::Vec;
 
 // This is defined here, in a private submodule, so we can explicitly reexport
 // it only as `pub(crate)`. This avoids a ton of

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -14,8 +14,8 @@ use self::table::create_table;
 use crate::store::{InstanceId, StoreOpaque};
 use crate::{GlobalType, MemoryType, TableType, Val};
 use anyhow::Result;
-use std::any::Any;
-use std::sync::Arc;
+use core::any::Any;
+use alloc::{boxed::Box, sync::Arc};
 use wasmtime_environ::{EntityIndex, GlobalIndex, MemoryIndex, Module, TableIndex};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator,
@@ -49,7 +49,7 @@ fn create_handle(
                 store: Some(store.traitobj()),
                 wasm_data: &[],
             },
-        )?;
+        ).map_err(anyhow::Error::msg)?;
 
         Ok(store.add_instance(handle, true))
     }

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -2,6 +2,7 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::{GlobalType, Mutability, Val};
 use anyhow::Result;
+use alloc::{boxed::Box, string::String, vec::Vec};
 use wasmtime_environ::{EntityIndex, Global, GlobalInit, Module, ModuleType, SignatureIndex};
 use wasmtime_runtime::VMFunctionImport;
 

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -3,8 +3,8 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::MemoryType;
 use anyhow::{anyhow, Result};
-use std::convert::TryFrom;
-use std::sync::Arc;
+use core::convert::TryFrom;
+use alloc::{boxed::Box, string::String, sync::Arc};
 use wasmtime_environ::{EntityIndex, MemoryPlan, MemoryStyle, Module, WASM_PAGE_SIZE};
 use wasmtime_runtime::{RuntimeLinearMemory, RuntimeMemoryCreator, VMMemoryDefinition};
 

--- a/crates/wasmtime/src/trampoline/table.rs
+++ b/crates/wasmtime/src/trampoline/table.rs
@@ -2,6 +2,7 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::TableType;
 use anyhow::Result;
+use alloc::{boxed::Box, string::String};
 use wasmtime_environ::{EntityIndex, Module};
 
 pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<InstanceId> {

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use core::fmt;
+use alloc::{borrow::ToOwned, string::{String, ToString}, vec::Vec};
 use wasmtime_environ::{EntityType, Global, Memory, Table, WasmFuncType, WasmType};
 use wasmtime_jit::TypeTables;
 

--- a/crates/wasmtime/src/types/matching.rs
+++ b/crates/wasmtime/src/types/matching.rs
@@ -3,6 +3,7 @@ use crate::linker::Definition;
 use crate::store::StoreOpaque;
 use crate::{signatures::SignatureCollection, Engine, Extern};
 use anyhow::{bail, Context, Result};
+use alloc::{format, string::{String, ToString}, vec::Vec};
 use wasmtime_environ::{
     EntityType, Global, InstanceTypeIndex, Memory, ModuleTypeIndex, SignatureIndex, Table,
     WasmFuncType, WasmType,

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -2,7 +2,7 @@ use crate::r#ref::ExternRef;
 use crate::store::StoreOpaque;
 use crate::{AsContextMut, Func, ValType};
 use anyhow::{bail, Result};
-use std::ptr;
+use core::ptr;
 use wasmtime_runtime::TableElement;
 
 pub use wasmtime_runtime::ValRaw;


### PR DESCRIPTION
526 Theseus OS - fixing warnings

It fixes warnings when I run the clippy lint. This is a submodule of Theseus OS.

There are no test cases. I don't think they are meaningful.

I don't know who can review this.

I don't think I broke anything, but can only test on Theseus OS. 
